### PR TITLE
Added BasePayloadTypeAdapter to fix Serialization Issues

### DIFF
--- a/src/main/java/com/github/segmentio/gson/BasePayloadTypeAdapter.java
+++ b/src/main/java/com/github/segmentio/gson/BasePayloadTypeAdapter.java
@@ -1,0 +1,16 @@
+package com.github.segmentio.gson;
+
+import java.lang.reflect.Type;
+
+import com.github.segmentio.models.BasePayload;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+public class BasePayloadTypeAdapter
+    implements JsonSerializer<BasePayload>
+{
+  public JsonElement serialize(BasePayload payload, Type type, JsonSerializationContext context) {
+    return context.serialize(payload, payload.getClass());
+  }
+}

--- a/src/main/java/com/github/segmentio/utils/GSONUtils.java
+++ b/src/main/java/com/github/segmentio/utils/GSONUtils.java
@@ -1,12 +1,14 @@
 package com.github.segmentio.utils;
 
-import org.joda.time.DateTime;
-import com.google.gson.GsonBuilder;
+import com.github.segmentio.gson.BasePayloadTypeAdapter;
 import com.github.segmentio.gson.DateTimeTypeConverter;
+import com.github.segmentio.models.BasePayload;
+import com.google.gson.GsonBuilder;
+import org.joda.time.DateTime;
 
 public class GSONUtils {
 
-	public static final GsonBuilder BUILDER = new GsonBuilder()
-		.registerTypeAdapter(DateTime.class,new DateTimeTypeConverter());
-
+       public static final GsonBuilder BUILDER = new GsonBuilder()
+               .registerTypeAdapter(DateTime.class, new DateTimeTypeConverter())
+               .registerTypeAdapter(BasePayload.class, new BasePayloadTypeAdapter());
 }

--- a/src/test/java/com/github/segmentio/gson/BasePayloadTypeAdapterTest.java
+++ b/src/test/java/com/github/segmentio/gson/BasePayloadTypeAdapterTest.java
@@ -1,0 +1,103 @@
+package com.github.segmentio.gson;
+
+import java.util.Arrays;
+
+import com.github.segmentio.models.Alias;
+import com.github.segmentio.models.BasePayload;
+import com.github.segmentio.models.Batch;
+import com.github.segmentio.models.Group;
+import com.github.segmentio.models.Identify;
+import com.github.segmentio.models.Options;
+import com.github.segmentio.models.Page;
+import com.github.segmentio.models.Props;
+import com.github.segmentio.models.Screen;
+import com.github.segmentio.models.Track;
+import com.github.segmentio.models.Traits;
+import com.github.segmentio.utils.GSONUtils;
+import com.google.gson.Gson;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class BasePayloadTypeAdapterTest
+{
+
+  private Gson gson;
+  private String testCategory = "test-category";
+  private String testName = "test-name";
+  private String testWriteKey = "test-write-key";
+  private String testUserId = "test-user-id";
+  private Traits testTraits = new Traits().put("test-trait-key", "test-trait-value");
+  private Options testOptions = new Options().setIntegration("all", false);
+  private Props testProperties = new Props().put("test-prop-key", "test-prop-value");
+
+  @Before
+  public void setup() {
+    gson = GSONUtils.BUILDER.create();
+  }
+
+  @Test
+  public void testBasePayloadSerialization() {
+    BasePayload payload = new Identify(testUserId, testTraits, testOptions);
+    Batch batch = new Batch(testWriteKey, Arrays.asList(payload));
+    String json = gson.toJson(batch);
+    assertJson(json, "identify");
+    assertJsonMap(json, "test-trait-key", "test-trait-value");
+    assertJsonOptions(json, "all", "false");
+
+    payload = new Alias(testUserId, testUserId, testOptions);
+    batch = new Batch(testWriteKey, Arrays.asList(payload));
+    json = gson.toJson(batch);
+    assertJson(json, "alias");
+    assertJsonOptions(json, "all", "false");
+
+    payload = new Group(testUserId, testUserId, testTraits, testOptions);
+    batch = new Batch(testWriteKey, Arrays.asList(payload));
+    json = gson.toJson(batch);
+    assertJson(json, "group");
+    assertJsonMap(json, "test-trait-key", "test-trait-value");
+    assertJsonOptions(json, "all", "false");
+
+    payload = new Page(testUserId, testName, testCategory, testProperties, testOptions);
+    batch = new Batch(testWriteKey, Arrays.asList(payload));
+    json = gson.toJson(batch);
+    assertJson(json, "page");
+    assertTrue(json.contains(testName));
+    assertTrue(json.contains(testCategory));
+    assertJsonMap(json, "test-prop-key", "test-prop-value");
+    assertJsonOptions(json, "all", "false");
+
+    payload = new Screen(testUserId, testName, testCategory, testProperties, testOptions);
+    batch = new Batch(testWriteKey, Arrays.asList(payload));
+    json = gson.toJson(batch);
+    assertJson(json, "screen");
+    assertTrue(json.contains(testName));
+    assertTrue(json.contains(testCategory));
+    assertJsonMap(json, "test-prop-key", "test-prop-value");
+    assertJsonOptions(json, "all", "false");
+
+    payload = new Track(testUserId, testName, testProperties, testOptions);
+    batch = new Batch(testWriteKey, Arrays.asList(payload));
+    json = gson.toJson(batch);
+    assertJson(json, "track");
+    assertTrue(json.contains(testName));
+    assertJsonMap(json, "test-prop-key", "test-prop-value");
+    assertJsonOptions(json, "all", "false");
+  }
+
+  private void assertJson(String json, String type) {
+    assertTrue(json.contains(type));
+    assertTrue(json.contains(testUserId));
+  }
+
+  private void assertJsonMap(String json, String key, String value) {
+    assertTrue(json.contains(key));
+    assertTrue(json.contains(value));
+  }
+
+  private void assertJsonOptions(String json, String optionKey, String optionValue) {
+    assertTrue(json.contains(optionKey));
+    assertTrue(json.contains(optionValue));
+  }
+}


### PR DESCRIPTION
Subclasses of BasePayload were not properly serialized as Gson lacked an adapter to convert from the parent to its base class. This left much of the API unusable as the userId, nor anonymousId, was not included in the rest call despite being set on the various payload objects. 
