### PR TITLE
Update HttpClient to 4.3.5 to fix CVE-2014-3577.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.3.1</version>
+        <version>4.3.5</version>
     </dependency>
 
 	<dependency>


### PR DESCRIPTION
http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3577

Very small change that doesn't affect the API but fixes a potential man-in-the-middle vulnerability.
