### PR TITLE
Java 8 Javadoc fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,8 @@ tmp/
 *~.nib
 local.properties
 .settings/
+.classpath
+.project
 .loadpath
 
 # External tool builders

--- a/src/main/java/com/github/segmentio/Config.java
+++ b/src/main/java/com/github/segmentio/Config.java
@@ -156,7 +156,7 @@ public class Config {
 
 	/**
 	 * Sets the milliseconds to wait between request retries
-	 * @param timeout backoff in milliseconds.
+	 * @param backoff in milliseconds.
 	 */
 	public Config setBackoff(int backoff) {
 		if (backoff < 0)


### PR DESCRIPTION
In Java 8 javadoc linting is treated as errors, so a small fix was necessary
Also ignored more Eclipse project files.
