### PR TITLE
Make Properties objects internally immutable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
 		<artifactId>commons-lang3</artifactId>
 		<version>3.3</version>
 	</dependency>
+    
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>18.0</version>
+    </dependency>
 
 	<dependency>
 		<groupId>org.slf4j</groupId>
@@ -86,7 +92,7 @@
 	<dependency>
 		<groupId>com.google.code.gson</groupId>
 		<artifactId>gson</artifactId>
-		<version>2.2.4</version>
+		<version>2.3</version>
 	</dependency>
 
     <dependency>

--- a/src/main/java/com/github/segmentio/AnalyticsClient.java
+++ b/src/main/java/com/github/segmentio/AnalyticsClient.java
@@ -22,6 +22,7 @@ import com.github.segmentio.models.Traits;
 import com.github.segmentio.request.IRequester;
 import com.github.segmentio.request.RetryingRequester;
 import com.github.segmentio.stats.AnalyticsStatistics;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * The Segment.io Client - Instantiate this to use the Segment.io API.

--- a/src/main/java/com/github/segmentio/models/Page.java
+++ b/src/main/java/com/github/segmentio/models/Page.java
@@ -1,12 +1,11 @@
 package com.github.segmentio.models;
 
 
-public class Page extends BasePayload {
+public class Page extends PropertyPayload {
 
 	private String userId;
 	private String name;
 	private String category;
-	private Props properties;
 	
 	public Page(String userId, 
 				String name,
@@ -14,14 +13,11 @@ public class Page extends BasePayload {
 				Props properties, 
 				Options options) {
 		
-		super("page", options);
+		super("page", properties, options);
 
-		if (properties == null) properties = new Props();
-		
 		this.userId = userId;
 		this.name = name;
 		this.category = category;
-		this.properties = properties;
 	}
 
 	public String getUserId() {
@@ -46,14 +42,6 @@ public class Page extends BasePayload {
 	
 	public void setCategory(String category) {
 		this.category = category;
-	}
-	
-	public Props getProperties() {
-		return properties;
-	}
-	
-	public void setProperties(Props properties) {
-		this.properties = properties;
 	}
 	
 }

--- a/src/main/java/com/github/segmentio/models/PropertyPayload.java
+++ b/src/main/java/com/github/segmentio/models/PropertyPayload.java
@@ -1,0 +1,33 @@
+package com.github.segmentio.models;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * A payload that has a list of properties
+ * 
+ * @author jpollak
+ *
+ */
+public class PropertyPayload extends BasePayload {
+
+	private ImmutableMap<String, Object> properties;
+	
+	public PropertyPayload(String type, 
+			Props properties, 
+			Options options) {
+		super(type, options);
+		
+		if (properties == null) properties = new Props();
+
+		this.properties = ImmutableMap.copyOf(properties);
+	}
+	
+	public ImmutableMap<String, Object> getProperties() {
+		return properties;
+	}
+	
+	public void setProperties(Props properties) {
+		this.properties = ImmutableMap.copyOf(properties);
+	}
+
+}

--- a/src/main/java/com/github/segmentio/models/Screen.java
+++ b/src/main/java/com/github/segmentio/models/Screen.java
@@ -1,12 +1,11 @@
 package com.github.segmentio.models;
 
 
-public class Screen extends BasePayload {
+public class Screen extends PropertyPayload {
 
 	private String userId;
 	private String name;
 	private String category;
-	private Props properties;
 	
 	public Screen(String userId, 
 				String name,
@@ -14,14 +13,11 @@ public class Screen extends BasePayload {
 				Props properties, 
 				Options options) {
 		
-		super("screen", options);
+		super("screen", properties, options);
 
-		if (properties == null) properties = new Props();
-		
 		this.userId = userId;
 		this.name = name;
 		this.category = category;
-		this.properties = properties;
 	}
 
 	public String getUserId() {
@@ -46,14 +42,6 @@ public class Screen extends BasePayload {
 	
 	public void setCategory(String category) {
 		this.category = category;
-	}
-	
-	public Props getProperties() {
-		return properties;
-	}
-	
-	public void setProperties(Props properties) {
-		this.properties = properties;
 	}
 	
 }

--- a/src/main/java/com/github/segmentio/models/Track.java
+++ b/src/main/java/com/github/segmentio/models/Track.java
@@ -1,24 +1,22 @@
 package com.github.segmentio.models;
 
 
-public class Track extends BasePayload {
+public class Track extends PropertyPayload {
 
 	private String userId;
 	private String event;
-	private Props properties;
 	
 	public Track(String userId, 
 				 String event, 
 				 Props properties, 
 				 Options options) {
 		
-		super("track", options);
+		super("track", properties, options);
 
 		if (properties == null) properties = new Props();
 		
 		this.userId = userId;
 		this.event = event;
-		this.properties = properties;
 	}
 
 	public String getUserId() {
@@ -36,13 +34,5 @@ public class Track extends BasePayload {
 	public void setEvent(String event) {
 		this.event = event;
 	}
-	
-	public Props getProperties() {
-		return properties;
-	}
-	
-	public void setProperties(Props properties) {
-		this.properties = properties;
-	}
-	
+		
 }


### PR DESCRIPTION
This prevents ConcurrentModificationExceptions if the Props object is used elsewhere outside the Analytics library as the Flusher is serializing the Props.

This solves at least one root cause of https://github.com/segmentio/analytics-java/issues/31
