### PR TITLE
Relax signature of map types

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/messages/AliasMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/AliasMessage.java
@@ -53,7 +53,7 @@ public abstract class AliasMessage implements Message {
     }
 
     @Override protected AliasMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, Object> context, UUID anonymousId, String userId,
+        Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_AliasMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, previousId);

--- a/analytics-core/src/main/java/com/segment/analytics/messages/Batch.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/Batch.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 @AutoValue @AutoGson public abstract class Batch {
-  public static Batch create(Map<String, Object> context, List<Message> batch) {
+  public static Batch create(Map<String, ?> context, List<Message> batch) {
     return new AutoValue_Batch(batch, new Date(), context);
   }
 
@@ -15,5 +15,5 @@ import java.util.Map;
 
   public abstract Date sentAt();
 
-  public abstract Map<String, Object> context();
+  public abstract Map<String, ?> context();
 }

--- a/analytics-core/src/main/java/com/segment/analytics/messages/GroupMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/GroupMessage.java
@@ -35,7 +35,7 @@ public abstract class GroupMessage implements Message {
 
   public abstract String groupId();
 
-  @Nullable public abstract Map<String, Object> traits();
+  @Nullable public abstract Map<String, ?> traits();
 
   public Builder toBuilder() {
     return new Builder(this);
@@ -44,7 +44,7 @@ public abstract class GroupMessage implements Message {
   /** Fluent API for creating {@link GroupMessage} instances. */
   public static class Builder extends MessageBuilder<GroupMessage, Builder> {
     private String groupId;
-    private Map<String, Object> traits;
+    private Map<String, ?> traits;
 
     private Builder(GroupMessage group) {
       super(group);
@@ -65,7 +65,7 @@ public abstract class GroupMessage implements Message {
      *
      * @see <a href="https://segment.com/docs/spec/group/#traits">Traits</a>
      */
-    public Builder traits(Map<String, Object> traits) {
+    public Builder traits(Map<String, ?> traits) {
       if (traits == null) {
         throw new NullPointerException("Null traits");
       }
@@ -74,7 +74,7 @@ public abstract class GroupMessage implements Message {
     }
 
     @Override protected GroupMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, Object> context, UUID anonymousId, String userId,
+        Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_GroupMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, groupId, traits);

--- a/analytics-core/src/main/java/com/segment/analytics/messages/IdentifyMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/IdentifyMessage.java
@@ -24,7 +24,7 @@ public abstract class IdentifyMessage implements Message {
     return new Builder();
   }
 
-  @Nullable public abstract Map<String, Object> traits();
+  @Nullable public abstract Map<String, ?> traits();
 
   public Builder toBuilder() {
     return new Builder(this);
@@ -32,7 +32,7 @@ public abstract class IdentifyMessage implements Message {
 
   /** Fluent API for creating {@link IdentifyMessage} instances. */
   public static class Builder extends MessageBuilder<IdentifyMessage, Builder> {
-    private Map<String, Object> traits;
+    private Map<String, ?> traits;
 
     private Builder(IdentifyMessage identify) {
       super(identify);
@@ -48,7 +48,7 @@ public abstract class IdentifyMessage implements Message {
      *
      * @see <a href="https://segment.com/docs/spec/identify/#traits">Traits</a>
      */
-    public Builder traits(Map<String, Object> traits) {
+    public Builder traits(Map<String, ?> traits) {
       if (traits == null) {
         throw new NullPointerException("Null traits");
       }
@@ -57,7 +57,7 @@ public abstract class IdentifyMessage implements Message {
     }
 
     @Override protected IdentifyMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, Object> context, UUID anonymousId, String userId,
+        Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       if (userId == null && traits == null) {
         throw new IllegalStateException("Either userId or traits must be provided.");

--- a/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
@@ -16,7 +16,7 @@ public interface Message {
 
   Date timestamp();
 
-  @Nullable Map<String, Object> context();
+  @Nullable Map<String, ?> context();
 
   @Nullable UUID anonymousId();
 

--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -15,7 +15,7 @@ import java.util.UUID;
  */
 public abstract class MessageBuilder<T extends Message, V extends MessageBuilder> {
   private final Message.Type type;
-  private Map<String, Object> context;
+  private Map<String, ?> context;
   private UUID anonymousId;
   private String userId;
   private ImmutableMap.Builder<String, Object> integrationsBuilder;
@@ -50,7 +50,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    *
    * @see <a href="https://segment.com/docs/spec/common/#context">Context</a>
    */
-  public V context(Map<String, ? super Object> context) {
+  public V context(Map<String, ?> context) {
     if (context == null) {
       throw new NullPointerException("Null context");
     }
@@ -137,7 +137,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
   }
 
   protected abstract T realBuild(Message.Type type, UUID messageId, Date timestamp,
-      Map<String, Object> context, UUID anonymousId, String userId,
+      Map<String, ?> context, UUID anonymousId, String userId,
       Map<String, Object> integrations);
 
   abstract V self();

--- a/analytics-core/src/main/java/com/segment/analytics/messages/ScreenMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/ScreenMessage.java
@@ -32,7 +32,7 @@ public abstract class ScreenMessage implements Message {
 
   @Nullable public abstract String name();
 
-  @Nullable public abstract Map<String, Object> properties();
+  @Nullable public abstract Map<String, ?> properties();
 
   public Builder toBuilder() {
     return new Builder(this);
@@ -41,7 +41,7 @@ public abstract class ScreenMessage implements Message {
   /** Fluent API for creating {@link ScreenMessage} instances. */
   public static class Builder extends MessageBuilder<ScreenMessage, Builder> {
     private String name;
-    private Map<String, Object> properties;
+    private Map<String, ?> properties;
 
     private Builder(ScreenMessage screen) {
       super(screen);
@@ -62,7 +62,7 @@ public abstract class ScreenMessage implements Message {
      *
      * @see <a href="https://segment.com/docs/spec/screen/#properties">Properties</a>
      */
-    public Builder properties(Map<String, Object> properties) {
+    public Builder properties(Map<String, ?> properties) {
       if (properties == null) {
         throw new NullPointerException("Null properties");
       }
@@ -75,7 +75,7 @@ public abstract class ScreenMessage implements Message {
     }
 
     @Override protected ScreenMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, Object> context, UUID anonymousId, String userId,
+        Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_ScreenMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, name, properties);

--- a/analytics-core/src/main/java/com/segment/analytics/messages/TrackMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/TrackMessage.java
@@ -32,7 +32,7 @@ public abstract class TrackMessage implements Message {
 
   public abstract String event();
 
-  @Nullable public abstract Map<String, Object> properties();
+  @Nullable public abstract Map<String, ?> properties();
 
   public Builder toBuilder() {
     return new Builder(this);
@@ -41,7 +41,7 @@ public abstract class TrackMessage implements Message {
   /** Fluent API for creating {@link TrackMessage} instances. */
   public static class Builder extends MessageBuilder<TrackMessage, Builder> {
     private String event;
-    private Map<String, Object> properties;
+    private Map<String, ?> properties;
 
     private Builder(TrackMessage track) {
       super(track);
@@ -62,7 +62,7 @@ public abstract class TrackMessage implements Message {
      *
      * @see <a href="https://segment.com/docs/spec/track/#properties">Properties</a>
      */
-    public Builder properties(Map<String, Object> properties) {
+    public Builder properties(Map<String, ?> properties) {
       if (properties == null) {
         throw new NullPointerException("Null properties");
       }
@@ -75,7 +75,7 @@ public abstract class TrackMessage implements Message {
     }
 
     @Override protected TrackMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, Object> context, UUID anonymousId, String userId,
+        Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_TrackMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, event, properties);

--- a/analytics-sample/src/main/java/sample/Sample.java
+++ b/analytics-sample/src/main/java/sample/Sample.java
@@ -27,7 +27,7 @@ public class Sample {
           super.run();
           for (int i = 0; i < 10; i++) {
             analytics.enqueue(TrackMessage.builder("Java Test")
-                .properties(ImmutableMap.<String, Object>of("count", count.incrementAndGet()))
+                .properties(ImmutableMap.of("count", count.incrementAndGet()))
                 .userId("prateek"));
           }
           analytics.flush();

--- a/analytics/src/main/java/com/segment/analytics/internal/AnalyticsClient.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/AnalyticsClient.java
@@ -20,14 +20,14 @@ import java.util.concurrent.TimeUnit;
 import retrofit.RetrofitError;
 
 public class AnalyticsClient {
-  private static final Map<String, Object> CONTEXT;
+  private static final Map<String, ?> CONTEXT;
 
   static {
     ImmutableMap<String, String> library = new ImmutableMap.Builder<String, String>() //
         .put("name", "analytics-java") //
         .put("version", AnalyticsVersion.get()) //
         .build();
-    CONTEXT = ImmutableMap.<String, Object>of("library", library);
+    CONTEXT = ImmutableMap.of("library", library);
   }
 
   private final BlockingQueue<Message> messageQueue;

--- a/analytics/src/main/java/com/segment/analytics/internal/FlushMessage.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/FlushMessage.java
@@ -24,7 +24,7 @@ class FlushMessage implements Message {
     throw new UnsupportedOperationException();
   }
 
-  @Nullable @Override public Map<String, Object> context() {
+  @Nullable @Override public Map<String, ?> context() {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
So that users dont have to cast their maps to < String, Object > . 

Closes #63 