### PR TITLE
Supply Retrofit log messages to log correct.

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -274,7 +274,7 @@ public class Analytics {
           .setLogLevel(RestAdapter.LogLevel.FULL)
           .setLog(new RestAdapter.Log() {
             @Override public void log(String message) {
-              log.print(Log.Level.VERBOSE, message);
+              log.print(Log.Level.VERBOSE, "%s", message);
             }
           })
           .build();


### PR DESCRIPTION
Previously the raw retrofit message was being supplied as the "format"
argument to the log provided by the client.

This was problematic because this will caused most default
implementations of log to call String.format(msg), with potentially
unescaped "formatting" characters.

e.g. `analytics.enqueue(TrackMessage.builder("
Test").userId("1%5z90951"))` will fail the batch with this message:
retrofit.RetrofitError: Conversion = 'z'

because it String.format thinks %5z is formatting directive.

This change fixes it so that "%s" is passed as the format of the log
message, and the retrofit message is substituted in place.