### PR TITLE
Add ability to override message id

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/messages/AliasMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/AliasMessage.java
@@ -52,7 +52,7 @@ public abstract class AliasMessage implements Message {
       this.previousId = previousId;
     }
 
-    @Override protected AliasMessage realBuild(Type type, UUID messageId, Date timestamp,
+    @Override protected AliasMessage realBuild(Type type, String messageId, Date timestamp,
         Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_AliasMessage(type, messageId, timestamp, context, anonymousId, userId,

--- a/analytics-core/src/main/java/com/segment/analytics/messages/GroupMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/GroupMessage.java
@@ -72,7 +72,7 @@ public abstract class GroupMessage implements Message {
       return this;
     }
 
-    @Override protected GroupMessage realBuild(Type type, UUID messageId, Date timestamp,
+    @Override protected GroupMessage realBuild(Type type, String messageId, Date timestamp,
         Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_GroupMessage(type, messageId, timestamp, context, anonymousId, userId,

--- a/analytics-core/src/main/java/com/segment/analytics/messages/IdentifyMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/IdentifyMessage.java
@@ -55,7 +55,7 @@ public abstract class IdentifyMessage implements Message {
       return this;
     }
 
-    @Override protected IdentifyMessage realBuild(Type type, UUID messageId, Date timestamp,
+    @Override protected IdentifyMessage realBuild(Type type, String messageId, Date timestamp,
         Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       if (userId == null && traits == null) {

--- a/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
@@ -20,6 +20,8 @@ import javax.annotation.Nullable;
  * <a href="http://bit.ly/1N5v3Cq">Javadocs</a>.
  */
 public interface Message {
+  int MAX_MESSAGE_ID_LENGTH = 256;
+
   Type type();
 
   String messageId();

--- a/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 public interface Message {
   Type type();
 
-  UUID messageId();
+  String messageId();
 
   Date timestamp();
 

--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -14,7 +14,7 @@ import java.util.UUID;
  * result in a {@link IllegalStateException} at runtime.
  */
 public abstract class MessageBuilder<T extends Message, V extends MessageBuilder> {
-  private UUID messageId;
+  private String messageId;
   private final Message.Type type;
   private Map<String, ?> context;
   private UUID anonymousId;
@@ -46,7 +46,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    * The Message ID is a unique identifier for this message. If not specified, a random identifier will
    * be generated.
    */
-  public V messageId(UUID messageId) {
+  public V messageId(String messageId) {
     if (messageId == null) {
       throw new NullPointerException("Null messageId");
     }
@@ -150,7 +150,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
     return self();
   }
 
-  protected abstract T realBuild(Message.Type type, UUID messageId, Date timestamp,
+  protected abstract T realBuild(Message.Type type, String messageId, Date timestamp,
       Map<String, ?> context, UUID anonymousId, String userId, Map<String, Object> integrations);
 
   abstract V self();
@@ -166,7 +166,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
     }
     Map<String, Object> integrations = integrationsBuilder == null ? //
         Collections.<String, Object>emptyMap() : ImmutableMap.copyOf(integrationsBuilder);
-    return realBuild(type, messageId == null ? UUID.randomUUID() : messageId,
+    return realBuild(type, messageId == null ? UUID.randomUUID().toString() : messageId,
         timestamp == null ? new Date() : timestamp, context,
         anonymousId, userId, integrations);
   }

--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -43,7 +43,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
   }
 
   /**
-   * The Message ID is a unique identifier for this message. If not specified, a random identifier will
+   * The Message ID is a unique identifier for this message. If not specified, a unique identifier will
    * be generated.
    */
   public V messageId(String messageId) {

--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -50,6 +50,12 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
     if (messageId == null) {
       throw new NullPointerException("Null messageId");
     }
+    if (messageId.isEmpty()) {
+      throw new IllegalArgumentException("Empty messageId");
+    }
+    if (messageId.length() > Message.MAX_MESSAGE_ID_LENGTH) {
+      throw new IllegalArgumentException("messageId longer than " + Message.MAX_MESSAGE_ID_LENGTH + " characters");
+    }
     this.messageId = messageId;
     return self();
   }

--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -14,6 +14,7 @@ import java.util.UUID;
  * result in a {@link IllegalStateException} at runtime.
  */
 public abstract class MessageBuilder<T extends Message, V extends MessageBuilder> {
+  private UUID messageId;
   private final Message.Type type;
   private Map<String, ?> context;
   private UUID anonymousId;
@@ -29,6 +30,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
   }
 
   MessageBuilder(Message message) {
+    messageId = message.messageId();
     type = message.type();
     context = message.context();
     anonymousId = message.anonymousId();
@@ -38,6 +40,18 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
   /** Returns {@code true} if the given string is null or empty. */
   static boolean isNullOrEmpty(String string) {
     return string == null || string.trim().length() == 0;
+  }
+
+  /**
+   * The Message ID is a unique identifier for this message. If not specified, a random identifier will
+   * be generated.
+   */
+  public V messageId(UUID messageId) {
+    if (messageId == null) {
+      throw new NullPointerException("Null messageId");
+    }
+    this.messageId = messageId;
+    return self();
   }
 
   /**
@@ -152,7 +166,8 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
     }
     Map<String, Object> integrations = integrationsBuilder == null ? //
         Collections.<String, Object>emptyMap() : ImmutableMap.copyOf(integrationsBuilder);
-    return realBuild(type, UUID.randomUUID(), timestamp == null ? new Date() : timestamp, context,
+    return realBuild(type, messageId == null ? UUID.randomUUID() : messageId,
+        timestamp == null ? new Date() : timestamp, context,
         anonymousId, userId, integrations);
   }
 

--- a/analytics-core/src/main/java/com/segment/analytics/messages/PageMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/PageMessage.java
@@ -73,7 +73,7 @@ public abstract class PageMessage implements Message {
       return this;
     }
 
-    @Override protected PageMessage realBuild(Type type, UUID messageId, Date timestamp,
+    @Override protected PageMessage realBuild(Type type, String messageId, Date timestamp,
         Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_PageMessage(type, messageId, timestamp, context, anonymousId, userId,

--- a/analytics-core/src/main/java/com/segment/analytics/messages/ScreenMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/ScreenMessage.java
@@ -73,7 +73,7 @@ public abstract class ScreenMessage implements Message {
       return this;
     }
 
-    @Override protected ScreenMessage realBuild(Type type, UUID messageId, Date timestamp,
+    @Override protected ScreenMessage realBuild(Type type, String messageId, Date timestamp,
         Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_ScreenMessage(type, messageId, timestamp, context, anonymousId, userId,

--- a/analytics-core/src/main/java/com/segment/analytics/messages/TrackMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/TrackMessage.java
@@ -73,7 +73,7 @@ public abstract class TrackMessage implements Message {
       return this;
     }
 
-    @Override protected TrackMessage realBuild(Type type, UUID messageId, Date timestamp,
+    @Override protected TrackMessage realBuild(Type type, String messageId, Date timestamp,
         Map<String, ?> context, UUID anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_TrackMessage(type, messageId, timestamp, context, anonymousId, userId,

--- a/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
@@ -143,7 +143,7 @@ import static org.junit.Assert.fail;
   }
 
   @Test public void messageId(TestUtils.MessageBuilderTest builder) {
-    UUID messageId = UUID.randomUUID();
+    String messageId = UUID.randomUUID().toString();
 
     Message message = builder.get()
             .userId("foo")

--- a/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
@@ -142,6 +142,31 @@ import static org.junit.Assert.fail;
     }
   }
 
+  @Test
+  public void emptyMessageThrowsError(TestUtils.MessageBuilderTest builder) {
+    try {
+      builder.get().messageId("");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("Empty messageId");
+    }
+  }
+
+  @Test
+  public void largeMessageThrowsError(TestUtils.MessageBuilderTest builder) {
+    try {
+      StringBuffer buf = new StringBuffer();
+      for (int i = 0; i < 1024; i++) {
+        buf.append("x");
+      }
+
+      builder.get().messageId(buf.toString());
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("messageId longer than " + Message.MAX_MESSAGE_ID_LENGTH + " characters");
+    }
+  }
+
   @Test public void messageId(TestUtils.MessageBuilderTest builder) {
     String messageId = UUID.randomUUID().toString();
 

--- a/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
@@ -6,6 +6,8 @@ import com.squareup.burst.BurstJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
@@ -128,5 +130,26 @@ import static org.junit.Assert.fail;
     assertThat(message.integrations()).hasSize(2)
         .containsEntry("foo", false)
         .containsEntry("bar", ImmutableMap.of("qaz", "qux"));
+  }
+
+  @Test
+  public void nullMessageIdThrowsError(TestUtils.MessageBuilderTest builder) {
+    try {
+      builder.get().messageId(null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("Null messageId");
+    }
+  }
+
+  @Test public void messageId(TestUtils.MessageBuilderTest builder) {
+    UUID messageId = UUID.randomUUID();
+
+    Message message = builder.get()
+            .userId("foo")
+            .messageId(messageId)
+            .build();
+
+    assertThat(message.messageId()).isEqualTo(messageId);
   }
 }

--- a/analytics/src/main/java/com/segment/analytics/internal/FlushMessage.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/FlushMessage.java
@@ -16,7 +16,7 @@ class FlushMessage implements Message {
     throw new UnsupportedOperationException();
   }
 
-  @Override public UUID messageId() {
+  @Override public String messageId() {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
This PR adds the ability to override the auto-generated message id. We are generating our own internal UUIDs for our events, and would like them to be properly reflected in segment, so we needed to allow the segment client to let us set the UUIDs ourselves.