### PR TITLE
Make endpoint configurable.

### DIFF
--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -147,6 +147,31 @@ public class AnalyticsBuilderTest {
     }
   }
 
+  @Test public void nullEndpoint() {
+    try {
+      builder.endpoint(null);
+      fail("Should fail for null endpoint");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+    }
+  }
+
+  @Test public void emptyEndpoint() {
+    try {
+      builder.endpoint("");
+      fail("Should fail for empty endpoint");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+    }
+
+    try {
+      builder.endpoint("  ");
+      fail("Should fail for empty endpoint");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+    }
+  }
+
   @Test public void nullThreadFactory() {
     try {
       builder.threadFactory(null);


### PR DESCRIPTION
This enables use cases such as:

* pointing the client to a mock web server for testing
* pointing the client to proxy

Rebase + fixes of #87 (thanks @derarmin!)