### PR TITLE
Add APIs to allow setting a custom message ID.

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
@@ -3,6 +3,7 @@ package com.segment.analytics.messages;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -20,11 +21,11 @@ import javax.annotation.Nullable;
  * <a href="http://bit.ly/1N5v3Cq">Javadocs</a>.
  */
 public interface Message {
-  Type type();
+  @Nonnull Type type();
 
-  UUID messageId();
+  @Nonnull UUID messageId();
 
-  Date timestamp();
+  @Nonnull Date timestamp();
 
   @Nullable Map<String, ?> context();
 

--- a/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
@@ -3,13 +3,52 @@ package com.segment.analytics.messages;
 import com.google.common.collect.ImmutableMap;
 import com.segment.analytics.TestUtils;
 import com.squareup.burst.BurstJUnit4;
+import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-@RunWith(BurstJUnit4.class) public class MessageBuilderTest {
+@RunWith(BurstJUnit4.class)
+public class MessageBuilderTest {
+
+  @Test
+  public void nullMessageIdThrowsException(TestUtils.MessageBuilderTest builder) {
+    try {
+      builder.get().messageId(null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("Null messageId");
+    }
+  }
+
+  @Test
+  public void defaultMessageIdIsGenerated(TestUtils.MessageBuilderTest builder) {
+    Message message = builder.get().userId("foo").build();
+    assertThat(message.messageId()).isNotNull();
+  }
+
+  @Test
+  public void messageIdCanBeProvided(TestUtils.MessageBuilderTest builder) {
+    UUID uuid = UUID.randomUUID();
+    Message message = builder.get().userId("foo").messageId(uuid).build();
+    assertThat(message.messageId()).isNotNull();
+  }
+
+  @Test
+  public void defaultAnonymousIdIsNotGenerated(TestUtils.MessageBuilderTest builder) {
+    Message message = builder.get().userId("foo").build();
+    assertThat(message.anonymousId()).isNull();
+  }
+
+  @Test
+  public void anonymousIdCanBeProvided(TestUtils.MessageBuilderTest builder) {
+    UUID uuid = UUID.randomUUID();
+    // Must also provide a userId because identify requires `userId` or `traits`.
+    Message message = builder.get().anonymousId(uuid).userId("foo").build();
+    assertThat(message.anonymousId()).isEqualTo(uuid);
+  }
 
   @Test
   public void missingUserIdAndAnonymousIdThrowsException(TestUtils.MessageBuilderTest builder) {
@@ -32,7 +71,8 @@ import static org.junit.Assert.fail;
   }
 
   @Test public void providingUserIdBuildsSuccessfully(TestUtils.MessageBuilderTest builder) {
-    builder.get().userId("foo").build();
+    Message message = builder.get().userId("foo").build();
+    assertThat(message.userId()).isEqualToIgnoringCase("foo");
   }
 
   @Test public void aliasBuilder() {
@@ -116,6 +156,14 @@ import static org.junit.Assert.fail;
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("Null properties");
     }
+  }
+
+  @Test public void defaultIntegrationsIsGenerated(TestUtils.MessageBuilderTest builder) {
+    Message message = builder.get()
+        .userId("foo")
+        .build();
+
+    assertThat(message.integrations()).isEmpty();
   }
 
   @Test public void integrations(TestUtils.MessageBuilderTest builder) {

--- a/analytics/src/main/java/com/segment/analytics/internal/FlushMessage.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/FlushMessage.java
@@ -4,6 +4,7 @@ import com.segment.analytics.messages.Message;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 class FlushMessage implements Message {
@@ -12,15 +13,15 @@ class FlushMessage implements Message {
   private FlushMessage() {
   }
 
-  @Override public Type type() {
+  @Nonnull @Override public Type type() {
     throw new UnsupportedOperationException();
   }
 
-  @Override public UUID messageId() {
+  @Nonnull @Override public UUID messageId() {
     throw new UnsupportedOperationException();
   }
 
-  @Override public Date timestamp() {
+  @Nonnull @Override public Date timestamp() {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
To match the anonymous ID API, message IDs can currently only be UUIDs.

Also adds some tests for anonymous ID.

Closes #30 