### PR TITLE
Allow setting String ids in addition to UUIDs.

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/messages/AliasMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/AliasMessage.java
@@ -4,7 +4,6 @@ import com.google.auto.value.AutoValue;
 import com.segment.analytics.gson.AutoGson;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * The alias message is used to merge two user identities, effectively connecting two sets of user
@@ -52,8 +51,8 @@ public abstract class AliasMessage implements Message {
       this.previousId = previousId;
     }
 
-    @Override protected AliasMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, ?> context, UUID anonymousId, String userId,
+    @Override protected AliasMessage realBuild(Type type, String messageId, Date timestamp,
+        Map<String, ?> context, String anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_AliasMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, previousId);

--- a/analytics-core/src/main/java/com/segment/analytics/messages/GroupMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/GroupMessage.java
@@ -4,7 +4,6 @@ import com.google.auto.value.AutoValue;
 import com.segment.analytics.gson.AutoGson;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 import javax.annotation.Nullable;
 
 /**
@@ -72,8 +71,8 @@ public abstract class GroupMessage implements Message {
       return this;
     }
 
-    @Override protected GroupMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, ?> context, UUID anonymousId, String userId,
+    @Override protected GroupMessage realBuild(Type type, String messageId, Date timestamp,
+        Map<String, ?> context, String anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_GroupMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, groupId, traits);

--- a/analytics-core/src/main/java/com/segment/analytics/messages/IdentifyMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/IdentifyMessage.java
@@ -4,7 +4,6 @@ import com.google.auto.value.AutoValue;
 import com.segment.analytics.gson.AutoGson;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 import javax.annotation.Nullable;
 
 /**
@@ -55,8 +54,8 @@ public abstract class IdentifyMessage implements Message {
       return this;
     }
 
-    @Override protected IdentifyMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, ?> context, UUID anonymousId, String userId,
+    @Override protected IdentifyMessage realBuild(Type type, String messageId, Date timestamp,
+        Map<String, ?> context, String anonymousId, String userId,
         Map<String, Object> integrations) {
       if (userId == null && traits == null) {
         throw new IllegalStateException("Either userId or traits must be provided.");

--- a/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/Message.java
@@ -2,7 +2,6 @@ package com.segment.analytics.messages;
 
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -23,13 +22,13 @@ import javax.annotation.Nullable;
 public interface Message {
   @Nonnull Type type();
 
-  @Nonnull UUID messageId();
+  @Nonnull String messageId();
 
   @Nonnull Date timestamp();
 
   @Nullable Map<String, ?> context();
 
-  @Nullable UUID anonymousId();
+  @Nullable String anonymousId();
 
   @Nullable String userId();
 

--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -15,10 +15,10 @@ import java.util.UUID;
  */
 public abstract class MessageBuilder<T extends Message, V extends MessageBuilder> {
   private final Message.Type type;
-  private UUID messageId;
+  private String messageId;
   private Date timestamp;
   private Map<String, ?> context;
-  private UUID anonymousId;
+  private String anonymousId;
   private String userId;
   private Map<String, Object> integrations;
 
@@ -46,11 +46,27 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    * for you. This ID is typically used for deduping - messages with the same IDs as previous events
    * may be dropped.
    *
+   * @deprecated Use {@link #messageId(String)} instead.
    * @see <a href="https://segment.com/docs/spec/common/">Common Fields</a>
    */
   public V messageId(UUID messageId) {
     if (messageId == null) {
       throw new NullPointerException("Null messageId");
+    }
+    this.messageId = messageId.toString();
+    return self();
+  }
+
+  /**
+   * The Message ID is a unique identifier for each message. If not provided, one will be generated
+   * for you. This ID is typically used for deduping - messages with the same IDs as previous events
+   * may be dropped.
+   *
+   * @see <a href="https://segment.com/docs/spec/common/">Common Fields</a>
+   */
+  public V messageId(String messageId) {
+    if (isNullOrEmpty(messageId)) {
+      throw new IllegalArgumentException("messageId cannot be null or empty.");
     }
     this.messageId = messageId;
     return self();
@@ -92,12 +108,28 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    * The Anonymous ID is a pseudo-unique substitute for a User ID, for cases when you don’t have an
    * absolutely unique identifier.
    *
+   * @deprecated Use {@link #anonymousId(String)} instead.
    * @see <a href="https://segment.com/docs/spec/identify/#identities">Identities</a>
    * @see <a href="https://segment.com/docs/spec/identify/#anonymous-id">Anonymous ID</a>
    */
   public V anonymousId(UUID anonymousId) {
     if (anonymousId == null) {
       throw new NullPointerException("Null anonymousId");
+    }
+    this.anonymousId = anonymousId.toString();
+    return self();
+  }
+
+  /**
+   * The Anonymous ID is a pseudo-unique substitute for a User ID, for cases when you don’t have an
+   * absolutely unique identifier.
+   *
+   * @see <a href="https://segment.com/docs/spec/identify/#identities">Identities</a>
+   * @see <a href="https://segment.com/docs/spec/identify/#anonymous-id">Anonymous ID</a>
+   */
+  public V anonymousId(String anonymousId) {
+    if (isNullOrEmpty(anonymousId)) {
+      throw new IllegalArgumentException("anonymousId cannot be null or empty.");
     }
     this.anonymousId = anonymousId;
     return self();
@@ -151,8 +183,8 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
     return self();
   }
 
-  protected abstract T realBuild(Message.Type type, UUID messageId, Date timestamp,
-      Map<String, ?> context, UUID anonymousId, String userId, Map<String, Object> integrations);
+  protected abstract T realBuild(Message.Type type, String messageId, Date timestamp,
+      Map<String, ?> context, String anonymousId, String userId, Map<String, Object> integrations);
 
   abstract V self();
 
@@ -171,9 +203,9 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
       timestamp = new Date();
     }
 
-    UUID messageId = this.messageId;
+    String messageId = this.messageId;
     if (messageId == null) {
-      messageId = UUID.randomUUID();
+      messageId = UUID.randomUUID().toString();
     }
 
     Map<String, Object> integrations;

--- a/analytics-core/src/main/java/com/segment/analytics/messages/PageMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/PageMessage.java
@@ -4,7 +4,6 @@ import com.google.auto.value.AutoValue;
 import com.segment.analytics.gson.AutoGson;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 import javax.annotation.Nullable;
 
 /**
@@ -73,8 +72,8 @@ public abstract class PageMessage implements Message {
       return this;
     }
 
-    @Override protected PageMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, ?> context, UUID anonymousId, String userId,
+    @Override protected PageMessage realBuild(Type type, String messageId, Date timestamp,
+        Map<String, ?> context, String anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_PageMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, name, properties);

--- a/analytics-core/src/main/java/com/segment/analytics/messages/ScreenMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/ScreenMessage.java
@@ -4,7 +4,6 @@ import com.google.auto.value.AutoValue;
 import com.segment.analytics.gson.AutoGson;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 import javax.annotation.Nullable;
 
 /**
@@ -73,8 +72,8 @@ public abstract class ScreenMessage implements Message {
       return this;
     }
 
-    @Override protected ScreenMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, ?> context, UUID anonymousId, String userId,
+    @Override protected ScreenMessage realBuild(Type type, String messageId, Date timestamp,
+        Map<String, ?> context, String anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_ScreenMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, name, properties);

--- a/analytics-core/src/main/java/com/segment/analytics/messages/TrackMessage.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/TrackMessage.java
@@ -4,7 +4,6 @@ import com.google.auto.value.AutoValue;
 import com.segment.analytics.gson.AutoGson;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 import javax.annotation.Nullable;
 
 /**
@@ -73,8 +72,8 @@ public abstract class TrackMessage implements Message {
       return this;
     }
 
-    @Override protected TrackMessage realBuild(Type type, UUID messageId, Date timestamp,
-        Map<String, ?> context, UUID anonymousId, String userId,
+    @Override protected TrackMessage realBuild(Type type, String messageId, Date timestamp,
+        Map<String, ?> context, String anonymousId, String userId,
         Map<String, Object> integrations) {
       return new AutoValue_TrackMessage(type, messageId, timestamp, context, anonymousId, userId,
           integrations, event, properties);

--- a/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
@@ -14,9 +14,29 @@ import static org.junit.Assert.fail;
 public class MessageBuilderTest {
 
   @Test
-  public void nullMessageIdThrowsException(TestUtils.MessageBuilderTest builder) {
+  public void nullStringMessageIdThrowsException(TestUtils.MessageBuilderTest builder) {
     try {
-      builder.get().messageId(null);
+      builder.get().messageId((String) null);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("messageId cannot be null or empty.");
+    }
+  }
+
+  @Test
+  public void emptyStringMessageIdThrowsException(TestUtils.MessageBuilderTest builder) {
+    try {
+      builder.get().messageId("");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("messageId cannot be null or empty.");
+    }
+  }
+
+  @Test
+  public void nullUUIDMessageIdThrowsException(TestUtils.MessageBuilderTest builder) {
+    try {
+      builder.get().messageId((UUID) null);
       fail();
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("Null messageId");
@@ -47,7 +67,37 @@ public class MessageBuilderTest {
     UUID uuid = UUID.randomUUID();
     // Must also provide a userId because identify requires `userId` or `traits`.
     Message message = builder.get().anonymousId(uuid).userId("foo").build();
-    assertThat(message.anonymousId()).isEqualTo(uuid);
+    assertThat(message.anonymousId()).isEqualTo(uuid.toString());
+  }
+
+  @Test
+  public void nullStringAnonymousIdThrowsException(TestUtils.MessageBuilderTest builder) {
+    try {
+      builder.get().anonymousId((String) null);
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("anonymousId cannot be null or empty.");
+    }
+  }
+
+  @Test
+  public void emptyStringAnonymousIdThrowsException(TestUtils.MessageBuilderTest builder) {
+    try {
+      builder.get().anonymousId("");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("anonymousId cannot be null or empty.");
+    }
+  }
+
+  @Test
+  public void nullUUIDAnonymousIdThrowsException(TestUtils.MessageBuilderTest builder) {
+    try {
+      builder.get().anonymousId((UUID) null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("Null anonymousId");
+    }
   }
 
   @Test

--- a/analytics/src/main/java/com/segment/analytics/internal/FlushMessage.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/FlushMessage.java
@@ -17,7 +17,7 @@ class FlushMessage implements Message {
     throw new UnsupportedOperationException();
   }
 
-  @Nonnull @Override public UUID messageId() {
+  @Nonnull @Override public String messageId() {
     throw new UnsupportedOperationException();
   }
 
@@ -29,7 +29,7 @@ class FlushMessage implements Message {
     throw new UnsupportedOperationException();
   }
 
-  @Nullable @Override public UUID anonymousId() {
+  @Nullable @Override public String anonymousId() {
     throw new UnsupportedOperationException();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.segment.analytics.java</groupId>
   <artifactId>analytics-parent</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Analytics for Java (Parent)</name>
   <description>The hassle-free way to add analytics to your Android app.</description>


### PR DESCRIPTION
This is a breaking change, as previously the `messageId` and `anonymousId` methods used to return `UUID`, but now they return `String`.