### PR TITLE
Update E2E tests to use webhook-e2e.

### DIFF
--- a/.buildscript/e2e.sh
+++ b/.buildscript/e2e.sh
@@ -6,8 +6,8 @@ if [ "$RUN_E2E_TESTS" != "true" ]; then
   echo "Skipping end to end tests."
 else
   echo "Running end to end tests..."
-  wget https://github.com/segmentio/library-e2e-tester/releases/download/0.1.1/tester_linux_amd64
+  wget https://github.com/segmentio/library-e2e-tester/releases/download/0.2.0/tester_linux_amd64
   chmod +x tester_linux_amd64
-  ./tester_linux_amd64 -segment-write-key="$SEGMENT_WRITE_KEY" -runscope-token="$RUNSCOPE_TOKEN" -runscope-bucket="$RUNSCOPE_BUCKET" -path='.buildscript/cli.sh'
+  ./tester_linux_amd64 -segment-write-key="$SEGMENT_WRITE_KEY" -webhook-auth-username="$WEBHOOK_AUTH_USERNAME" -webhook-bucket="$WEBHOOK_BUCKET" -path='.buildscript/cli.sh'
   echo "End to end tests completed!"
 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,5 @@
 version: 2
 jobs:
-  build-jdklatest:
-    docker:
-      - image: circleci/openjdk
-    working_directory: ~/analytics-java
-    steps:
-      - checkout
-      - run: mvn package -B
-      - run: .buildscript/e2e.sh
   build-jdk8:
     docker:
       - image: circleci/openjdk:8-jdk-browsers


### PR DESCRIPTION
Uses the new version of the e2e testing tool. Changes described in https://github.com/segmentio/library-e2e-tester/releases/tag/0.2.0.

Additionally it inly runs CI against JDK 8 as the build fails on the latest version.