### PR TITLE
ISSUE-135: use JsonElement.getAsString() when deserializing dates / a…

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/gson/ISO8601DateAdapter.java
+++ b/analytics-core/src/main/java/com/segment/analytics/gson/ISO8601DateAdapter.java
@@ -23,6 +23,6 @@ public class ISO8601DateAdapter implements JsonSerializer<Date>, JsonDeserialize
   @Override
   public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
       throws JsonParseException {
-    return Iso8601Utils.parse(json.toString());
+    return Iso8601Utils.parse(json.getAsString());
   }
 }

--- a/analytics-core/src/test/java/com/segment/analytics/TestUtils.java
+++ b/analytics-core/src/test/java/com/segment/analytics/TestUtils.java
@@ -15,10 +15,6 @@ public final class TestUtils {
     throw new AssertionError("No instances.");
   }
 
-  public static final Gson GSON = new GsonBuilder()
-          .registerTypeAdapter(Date.class, new ISO8601DateAdapter())
-          .create();
-
   @SuppressWarnings("UnusedDeclaration")
   public enum MessageBuilderFactory {
     ALIAS {

--- a/analytics-core/src/test/java/com/segment/analytics/TestUtils.java
+++ b/analytics-core/src/test/java/com/segment/analytics/TestUtils.java
@@ -1,5 +1,8 @@
 package com.segment.analytics;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.segment.analytics.gson.ISO8601DateAdapter;
 import com.segment.analytics.messages.*;
 import java.util.Calendar;
 import java.util.Date;
@@ -11,6 +14,10 @@ public final class TestUtils {
   private TestUtils() {
     throw new AssertionError("No instances.");
   }
+
+  public static final Gson GSON = new GsonBuilder()
+          .registerTypeAdapter(Date.class, new ISO8601DateAdapter())
+          .create();
 
   @SuppressWarnings("UnusedDeclaration")
   public enum MessageBuilderFactory {

--- a/analytics-core/src/test/java/com/segment/analytics/gson/ISO8601DateAdapterTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/gson/ISO8601DateAdapterTest.java
@@ -1,0 +1,43 @@
+package com.segment.analytics.gson;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.segment.analytics.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static com.segment.analytics.TestUtils.newDate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ISO8601DateAdapterTest {
+
+    private static class TestModel {
+        final Date timestamp;
+        public TestModel(Date timestamp) {
+            this.timestamp = timestamp;
+        }
+    }
+
+    @Test
+    public void testSerializeDate() {
+        TestModel testModel = new TestModel(newDate(1996, 12, 19, 16, 39, 57, 0, -8 * 60));
+
+        JsonElement e = TestUtils.GSON.toJsonTree(testModel);
+        Assert.assertTrue(e.isJsonObject());
+
+        JsonObject o = e.getAsJsonObject();
+        Assert.assertTrue(o.has("timestamp"));
+
+        assertThat(o.get("timestamp").getAsString()).isEqualTo("1996-12-20T00:39:57.000Z");
+    }
+
+    @Test
+    public void testDeserializeDate() {
+        String serializedTestModel = "{\"timestamp\":\"1996-06-01T16:39:57.000Z\"}";
+        Date expected = newDate(1996, 06, 01, 16, 39, 57, 0, 0);
+        TestModel actual = TestUtils.GSON.fromJson(serializedTestModel, TestModel.class);
+        assertThat(actual.timestamp).isEqualTo(expected);
+    }
+}

--- a/analytics-core/src/test/java/com/segment/analytics/gson/ISO8601DateAdapterTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/gson/ISO8601DateAdapterTest.java
@@ -1,5 +1,7 @@
 package com.segment.analytics.gson;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.segment.analytics.TestUtils;
@@ -13,6 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ISO8601DateAdapterTest {
 
+    public static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapter(Date.class, new ISO8601DateAdapter())
+            .create();
+
     private static class TestModel {
         final Date timestamp;
         public TestModel(Date timestamp) {
@@ -24,7 +30,7 @@ public class ISO8601DateAdapterTest {
     public void testSerializeDate() {
         TestModel testModel = new TestModel(newDate(1996, 12, 19, 16, 39, 57, 0, -8 * 60));
 
-        JsonElement e = TestUtils.GSON.toJsonTree(testModel);
+        JsonElement e = GSON.toJsonTree(testModel);
         Assert.assertTrue(e.isJsonObject());
 
         JsonObject o = e.getAsJsonObject();
@@ -37,7 +43,7 @@ public class ISO8601DateAdapterTest {
     public void testDeserializeDate() {
         String serializedTestModel = "{\"timestamp\":\"1996-06-01T16:39:57.000Z\"}";
         Date expected = newDate(1996, 06, 01, 16, 39, 57, 0, 0);
-        TestModel actual = TestUtils.GSON.fromJson(serializedTestModel, TestModel.class);
+        TestModel actual = GSON.fromJson(serializedTestModel, TestModel.class);
         assertThat(actual.timestamp).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
- use JsonElement.getAsString() when deserializing dates
- adding tests for ISO8601DateAdapter