### PR TITLE
Remove errorprone from maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,24 +161,11 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
           <configuration>
-            <compilerId>javac-with-errorprone</compilerId>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
             <source>${java.version}</source>
             <target>${java.version}</target>
             <showWarnings>true</showWarnings>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.codehaus.plexus</groupId>
-              <artifactId>plexus-compiler-javac-errorprone</artifactId>
-              <version>2.8</version>
-            </dependency>
-            <dependency>
-              <groupId>com.google.errorprone</groupId>
-              <artifactId>error_prone_core</artifactId>
-              <version>2.3.1</version>
-            </dependency>
-          </dependencies>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Remove errorprone from maven-compiler-plugin's dependency, as it has not
been updated to work with Java 11.

ref: LIB-678