### PR TITLE
Fix scheduled e2e test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,12 +98,6 @@ workflows:
       - test-jdk10
       - test-jdk9
       - test-jdk8
-  e2e:
-    jobs:
-      - test
-      - e2e:
-          requires:
-            - test
   static_analysis:
     jobs:
       - test
@@ -136,7 +130,7 @@ workflows:
                 - master
                 - scheduled_e2e_testing
     jobs:
-      - test-jdklatest
-      - test-jdk10
-      - test-jdk9
-      - test-jdk8
+      - test
+      - e2e:
+          requires:
+            - test


### PR DESCRIPTION
Run e2e tests instead of multi-tests for the scheduled tests