### PR TITLE
Add functionality to set custom endpoint with host and prefix

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/http/SegmentService.java
+++ b/analytics-core/src/main/java/com/segment/analytics/http/SegmentService.java
@@ -6,6 +6,6 @@ import retrofit.http.POST;
 
 /** REST interface for the Segment API. */
 public interface SegmentService {
-  @POST("/v1/import")
+  @POST("/import")
   UploadResponse upload(@Body Batch batch);
 }

--- a/analytics-core/src/main/java/com/segment/analytics/http/SegmentService.java
+++ b/analytics-core/src/main/java/com/segment/analytics/http/SegmentService.java
@@ -6,6 +6,6 @@ import retrofit.http.POST;
 
 /** REST interface for the Segment API. */
 public interface SegmentService {
-  @POST("/import")
+  @POST("")
   UploadResponse upload(@Body Batch batch);
 }

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -96,14 +96,14 @@ public class Analytics {
   /** Fluent API for creating {@link Analytics} instances. */
   public static class Builder {
     private static final Endpoint DEFAULT_ENDPOINT =
-        Endpoints.newFixedEndpoint("https://api.segment.io");
+        Endpoints.newFixedEndpoint("https://api.segment.io/v1/import");
     private static final String DEFAULT_USER_AGENT = "analytics-java/" + AnalyticsVersion.get();
 
     private final String writeKey;
     private Client client;
     private Log log;
-    private Endpoint endpoint;
-    private Endpoint apiHap;
+    public Endpoint endpoint;
+    public Endpoint uploadURL;
     private String userAgent = DEFAULT_USER_AGENT;
     private List<MessageTransformer> messageTransformers;
     private List<MessageInterceptor> messageInterceptors;
@@ -146,7 +146,7 @@ public class Analytics {
       if (endpoint == null || endpoint.trim().length() == 0) {
         throw new NullPointerException("endpoint cannot be null or empty.");
       }
-      this.endpoint = Endpoints.newFixedEndpoint(endpoint + "/v1");
+      this.endpoint = Endpoints.newFixedEndpoint(endpoint + "/v1/import");
       return this;
     }
 
@@ -154,11 +154,11 @@ public class Analytics {
      * Set an endpoint (host and prefix) that this client should upload events to. Uses {@code
      * https://api.segment.io/v1} by default.
      */
-    public Builder setHostAndPrefixEndpoint(String apiHap) {
-      if (apiHap == null || apiHap.trim().length() == 0) {
+    public Builder setUploadURL(String uploadURL) {
+      if (uploadURL == null || uploadURL.trim().length() == 0) {
         throw new NullPointerException("endpoint cannot be null or empty.");
       }
-      this.apiHap = Endpoints.newFixedEndpoint(apiHap);
+      this.uploadURL = Endpoints.newFixedEndpoint(uploadURL);
       return this;
     }
 
@@ -276,12 +276,12 @@ public class Analytics {
               .registerTypeAdapter(Date.class, new ISO8601DateAdapter()) //
               .create();
 
-      if (endpoint == null && apiHap == null) {
+      if (endpoint == null && uploadURL == null) {
         endpoint = DEFAULT_ENDPOINT;
       }
 
-      if (endpoint == null && apiHap != null) {
-        endpoint = apiHap;
+      if (endpoint == null && uploadURL != null) {
+        endpoint = uploadURL;
       }
 
       if (client == null) {

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -103,6 +103,7 @@ public class Analytics {
     private Client client;
     private Log log;
     private Endpoint endpoint;
+    private Endpoint apiHap;
     private String userAgent = DEFAULT_USER_AGENT;
     private List<MessageTransformer> messageTransformers;
     private List<MessageInterceptor> messageInterceptors;
@@ -138,14 +139,26 @@ public class Analytics {
     }
 
     /**
-     * Set an endpoint that this client should upload events to. Uses {@code https://api.segment.io}
-     * by default.
+     * Set an endpoint (host only) that this client should upload events to. Uses {@code
+     * https://api.segment.io} by default.
      */
     public Builder endpoint(String endpoint) {
       if (endpoint == null || endpoint.trim().length() == 0) {
         throw new NullPointerException("endpoint cannot be null or empty.");
       }
-      this.endpoint = Endpoints.newFixedEndpoint(endpoint);
+      this.endpoint = Endpoints.newFixedEndpoint(endpoint + "/v1");
+      return this;
+    }
+
+    /**
+     * Set an endpoint (host and prefix) that this client should upload events to. Uses {@code
+     * https://api.segment.io/v1} by default.
+     */
+    public Builder setHostAndPrefixEndpoint(String apiHap) {
+      if (apiHap == null || apiHap.trim().length() == 0) {
+        throw new NullPointerException("endpoint cannot be null or empty.");
+      }
+      this.apiHap = Endpoints.newFixedEndpoint(apiHap);
       return this;
     }
 
@@ -263,9 +276,14 @@ public class Analytics {
               .registerTypeAdapter(Date.class, new ISO8601DateAdapter()) //
               .create();
 
-      if (endpoint == null) {
+      if (endpoint == null && apiHap == null) {
         endpoint = DEFAULT_ENDPOINT;
       }
+
+      if (endpoint == null && apiHap != null) {
+        endpoint = apiHap;
+      }
+
       if (client == null) {
         client = Platform.get().defaultClient();
       }

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -252,6 +252,39 @@ public class AnalyticsBuilderTest {
   }
 
   @Test
+  public void buildsWithValidHostAndPrefixEndpoint() {
+    Analytics analytics = builder.setHostAndPrefixEndpoint("https://example.com/v2").build();
+    assertThat(analytics).isNotNull();
+  }
+
+  @Test
+  public void nullHostAndPrefixEndpoint() {
+    try {
+      builder.setHostAndPrefixEndpoint(null);
+      fail("Should fail for null endpoint");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+    }
+  }
+
+  @Test
+  public void emptyHostAndPrefixEndpoint() {
+    try {
+      builder.setHostAndPrefixEndpoint("");
+      fail("Should fail for empty endpoint");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+    }
+
+    try {
+      builder.setHostAndPrefixEndpoint("  ");
+      fail("Should fail for empty endpoint");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("endpoint cannot be null or empty.");
+    }
+  }
+
+  @Test
   public void nullThreadFactory() {
     try {
       builder.threadFactory(null);

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -2,6 +2,7 @@ package com.segment.analytics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -252,15 +253,29 @@ public class AnalyticsBuilderTest {
   }
 
   @Test
-  public void buildsWithValidHostAndPrefixEndpoint() {
-    Analytics analytics = builder.setHostAndPrefixEndpoint("https://example.com/v2").build();
+  public void buildsCorrectEndpoint() {
+    Analytics analytics = builder.endpoint("https://api.segment.io").build();
+    String expectedURL = "https://api.segment.io/v1/import";
+    assertEquals(expectedURL, builder.endpoint.getUrl());
+  }
+
+  @Test
+  public void buildsWithValidUploadURL() {
+    Analytics analytics = builder.setUploadURL("https://example.com/v2/batch").build();
     assertThat(analytics).isNotNull();
+  }
+
+  @Test
+  public void buildsCorrectURLWithUploadURL() {
+    Analytics analytics = builder.setUploadURL("https://example.com/v2/batch").build();
+    String expectedURL = "https://example.com/v2/batch";
+    assertEquals(expectedURL, builder.endpoint.getUrl());
   }
 
   @Test
   public void nullHostAndPrefixEndpoint() {
     try {
-      builder.setHostAndPrefixEndpoint(null);
+      builder.setUploadURL(null);
       fail("Should fail for null endpoint");
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("endpoint cannot be null or empty.");
@@ -270,14 +285,14 @@ public class AnalyticsBuilderTest {
   @Test
   public void emptyHostAndPrefixEndpoint() {
     try {
-      builder.setHostAndPrefixEndpoint("");
+      builder.setUploadURL("");
       fail("Should fail for empty endpoint");
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("endpoint cannot be null or empty.");
     }
 
     try {
-      builder.setHostAndPrefixEndpoint("  ");
+      builder.setUploadURL("  ");
       fail("Should fail for empty endpoint");
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("endpoint cannot be null or empty.");


### PR DESCRIPTION
This PR adds functionality to match functionality we support in our a.js and mobile libraries to configure a custom proxy URL. The changes in this PR allow customers to configure a custom endpoint with the host, prefix, and event. The code previously only supported allowing customers to configure a custom host. There is a new method `setUploadURL` on the Builder that allows customers to configure this endpoint. The path`/v1/import` was extracted from the SegmentService interface and placed in the `endpoint()` method on the Builder. If a customer uses the `.endpoint()` method on the builder Segment will append a `/v1/import` to the fully formed URL. If a customer uses `setUploadURL()` they have full control over all components of the URL and we will not append anything.  