### PR TITLE
Fix integration options map

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -172,7 +172,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    *
    * @see <a href="https://segment.com/docs/spec/common/#integrations">Integrations</a>
    */
-  public V integrationOptions(String key, Map<String, ? super Object> options) {
+  public V integrationOptions(String key, Map<String, ?> options) {
     if (isNullOrEmpty(key)) {
       throw new IllegalArgumentException("Key cannot be null or empty.");
     }


### PR DESCRIPTION
The `Map<String, ? super Object>` takes values that are of `Object` class only.
This should actually be `Map<String, ? extends Object>`, which can be written in short as `Map<String, ?>`.