### PR TITLE
[WIP] Configurable max queue depth

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Platform.java
+++ b/analytics/src/main/java/com/segment/analytics/Platform.java
@@ -54,6 +54,10 @@ class Platform {
     };
   }
 
+  public int defaultMaxQueueSize() {
+    return 2147483647;
+  }
+
   public long defaultFlushIntervalInMillis() {
     return 10 * 1000; // 10s
   }

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -149,6 +149,29 @@ public class AnalyticsBuilderTest {
   }
 
   @Test
+  public void invalidMaxQueueSize() {
+    try {
+      builder.maxQueueSize(5);
+        fail("Should fail for maxQueueSize < 10");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("maxQueueSize must not be less than 10.");
+    }
+
+    try {
+      builder.maxQueueSize(-1);
+      fail("Should fail for non positive maxQueueSize");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("maxQueueSize must not be less than 10.");
+    }
+  }
+
+  @Test
+  public void buildsWithValidMaxQueueSize() {
+    Analytics analytics = builder.maxQueueSize(1000).build();
+    assertThat(analytics).isNotNull();
+  }
+
+  @Test
   public void invalidFlushQueueSize() {
     try {
       builder.flushQueueSize(0);
@@ -168,6 +191,29 @@ public class AnalyticsBuilderTest {
   @Test
   public void buildsWithValidFlushQueueSize() {
     Analytics analytics = builder.flushQueueSize(1).build();
+    assertThat(analytics).isNotNull();
+  }
+
+  @Test
+  public void invalidFlushQueueSizeAndMaxQueueSizeCombination() {
+    try {
+      builder.maxQueueSize(1000).flushQueueSize(1001).build();
+      fail("Should fail for maxQueueSize less than flushQueueSize");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("maxQueueSize must not be less than flushQueueSize.");
+    }
+
+    try {
+      builder.maxQueueSize(249).build();
+      fail("Should fail for maxQueueSize less than platform default flushQueueSize");
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("maxQueueSize must not be less than flushQueueSize.");
+    }
+  }
+
+  @Test
+  public void buildsWithValidFlushQueueSizeAndMaxQueueSizeCombination() {
+    Analytics analytics = builder.maxQueueSize(10000).flushQueueSize(500).build();
     assertThat(analytics).isNotNull();
   }
 


### PR DESCRIPTION
Allow users to configure a maximum number of messages to queue in memory before dropping messages.

The motivation for this change is to avoid unwanted, unbounded queuing of messages

In its current state this PR doesn't make a lot of sense unless the `networkExecutor` provided to the `AnalyticsClient` uses a synchronised queue, because the `looperExecutor` will constantly pull messages off the initial in memory message queue unless blocked or backpressured when submitting to the `networkExecutor`.