### PR TITLE
Fix sample in javadoc

### DIFF
--- a/analytics-sample/src/main/java/sample/BlockingFlush.java
+++ b/analytics-sample/src/main/java/sample/BlockingFlush.java
@@ -16,7 +16,7 @@ import java.util.concurrent.Phaser;
  * <pre><code>
  * BlockingFlush blockingFlush = BlockingFlush.create();
  * Analytics analytics = Analytics.builder(writeKey)
- *      .plugin(blockingFlush)
+ *      .plugin(blockingFlush.plugin())
  *      .build();
  *
  * // Do some work.


### PR DESCRIPTION
Hi! A very minor fix, but one that I lost several minutes to tracking down.

I recently was following this BlockingFlush example to integrate into a project and found that the example code fixed here did not compile when copied into the codebase.