### PR TITLE
ISSUE-164 Allow processing of already buffered messages on shutdown

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/internal/StopMessage.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/StopMessage.java
@@ -1,0 +1,61 @@
+package com.segment.analytics.internal;
+
+import com.segment.analytics.messages.Message;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Date;
+import java.util.Map;
+
+class StopMessage implements Message {
+  static final StopMessage STOP = new StopMessage();
+
+  private StopMessage() {}
+
+  @Nonnull
+  @Override
+  public Type type() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public String messageId() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Date timestamp() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nullable
+  @Override
+  public Map<String, ?> context() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nullable
+  @Override
+  public String anonymousId() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nullable
+  @Override
+  public String userId() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nullable
+  @Override
+  public Map<String, Object> integrations() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String toString() {
+    return "FlushMessage{}";
+  }
+}


### PR DESCRIPTION
- send a STOP signal to the looper on shutdown for
  - graceful shutdown
  - flushing the last messages that were buffered
- give a chance to the looper & network executors to gracefully
  shutdown, and timeout if necessary.
- do not accept more messages after shutdown but log at error level