### PR TITLE
Require either userId or anonymousId (aligns with other Segment SDK conventions)

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -128,9 +128,6 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    * @see <a href="https://segment.com/docs/spec/identify/#anonymous-id">Anonymous ID</a>
    */
   public V anonymousId(String anonymousId) {
-    if (isNullOrEmpty(anonymousId)) {
-      throw new IllegalArgumentException("anonymousId cannot be null or empty.");
-    }
     this.anonymousId = anonymousId;
     return self();
   }
@@ -142,9 +139,6 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    * @see <a href="https://segment.com/docs/spec/identify/#user-id">User ID</a>
    */
   public V userId(String userId) {
-    if (isNullOrEmpty(userId)) {
-      throw new IllegalArgumentException("userId cannot be null or empty.");
-    }
     this.userId = userId;
     return self();
   }

--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -194,8 +194,8 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    * @throws IllegalStateException if both anonymousId and userId are not provided.
    */
   public T build() {
-    if (anonymousId == null && userId == null) {
-      throw new IllegalStateException("Either anonymousId or userId must be provided.");
+    if (isNullOrEmpty(anonymousId) && isNullOrEmpty(null)) {
+      throw new IllegalArgumentException("Either anonymousId or userId must be provided.");
     }
 
     Date timestamp = this.timestamp;

--- a/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
+++ b/analytics-core/src/main/java/com/segment/analytics/messages/MessageBuilder.java
@@ -194,7 +194,7 @@ public abstract class MessageBuilder<T extends Message, V extends MessageBuilder
    * @throws IllegalStateException if both anonymousId and userId are not provided.
    */
   public T build() {
-    if (isNullOrEmpty(anonymousId) && isNullOrEmpty(null)) {
+    if (isNullOrEmpty(anonymousId) && isNullOrEmpty(userId)) {
       throw new IllegalArgumentException("Either anonymousId or userId must be provided.");
     }
 

--- a/analytics-core/src/test/java/com/segment/analytics/messages/IdentifyMessageTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/IdentifyMessageTest.java
@@ -50,6 +50,13 @@ public class IdentifyMessageTest {
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(exceptionMessage);
     }
+
+    IdentifyMessage message = IdentifyMessage.builder().userId("theUserId").build();
+    assertThat(message.userId()).isEqualTo("theUserId");
+
+    message = IdentifyMessage.builder().anonymousId("theAnonymousId").traits(ImmutableMap.of("foo", "bar")).build();
+    assertThat(message.anonymousId()).isEqualTo("theAnonymousId");
+    assertThat(message.traits()).isEqualTo(ImmutableMap.of("foo", "bar"));
   }
 
   @Test

--- a/analytics-core/src/test/java/com/segment/analytics/messages/IdentifyMessageTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/IdentifyMessageTest.java
@@ -54,7 +54,11 @@ public class IdentifyMessageTest {
     IdentifyMessage message = IdentifyMessage.builder().userId("theUserId").build();
     assertThat(message.userId()).isEqualTo("theUserId");
 
-    message = IdentifyMessage.builder().anonymousId("theAnonymousId").traits(ImmutableMap.of("foo", "bar")).build();
+    message =
+        IdentifyMessage.builder()
+            .anonymousId("theAnonymousId")
+            .traits(ImmutableMap.of("foo", "bar"))
+            .build();
     assertThat(message.anonymousId()).isEqualTo("theAnonymousId");
     assertThat(message.traits()).isEqualTo(ImmutableMap.of("foo", "bar"));
   }

--- a/analytics-core/src/test/java/com/segment/analytics/messages/IdentifyMessageTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/IdentifyMessageTest.java
@@ -1,6 +1,7 @@
 package com.segment.analytics.messages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
@@ -22,6 +23,32 @@ public class IdentifyMessageTest {
       IdentifyMessage.builder().userId("userId").build();
     } catch (IllegalStateException e) {
       assertThat(e).hasMessage("Either userId or traits must be provided.");
+    }
+  }
+
+  @Test
+  public void userIdOrAnonymousIdIsRequired() {
+    final String exceptionMessage = "Either anonymousId or userId must be provided.";
+
+    try {
+      IdentifyMessage.builder().build();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(exceptionMessage);
+    }
+
+    try {
+      IdentifyMessage.builder().userId(null).anonymousId((String) null).build();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(exceptionMessage);
+    }
+
+    try {
+      IdentifyMessage.builder().userId("").anonymousId("").build();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(exceptionMessage);
     }
   }
 

--- a/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
@@ -90,26 +90,6 @@ public class MessageBuilderTest {
   }
 
   @Test
-  public void nullStringAnonymousIdThrowsException(TestUtils.MessageBuilderFactory builder) {
-    try {
-      builder.get().anonymousId((String) null);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("anonymousId cannot be null or empty.");
-    }
-  }
-
-  @Test
-  public void emptyStringAnonymousIdThrowsException(TestUtils.MessageBuilderFactory builder) {
-    try {
-      builder.get().anonymousId("");
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("anonymousId cannot be null or empty.");
-    }
-  }
-
-  @Test
   public void nullUUIDAnonymousIdThrowsException(TestUtils.MessageBuilderFactory builder) {
     try {
       builder.get().anonymousId((UUID) null);
@@ -136,16 +116,6 @@ public class MessageBuilderTest {
       fail();
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("Null timestamp");
-    }
-  }
-
-  @Test
-  public void invalidUserIdThrows(TestUtils.MessageBuilderFactory builder) {
-    try {
-      builder.get().userId(null);
-      fail();
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessage("userId cannot be null or empty.");
     }
   }
 

--- a/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/MessageBuilderTest.java
@@ -124,7 +124,7 @@ public class MessageBuilderTest {
     try {
       builder.get().build();
       fail();
-    } catch (IllegalStateException e) {
+    } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage("Either anonymousId or userId must be provided.");
     }
   }

--- a/analytics-core/src/test/java/com/segment/analytics/messages/TrackMessageTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/TrackMessageTest.java
@@ -38,7 +38,7 @@ public class TrackMessageTest {
     assertThat(copy.event()).isEqualTo("event");
     assertThat(copy.properties()).isEqualTo(ImmutableMap.of("foo", "bar"));
   }
-  
+
   @Test
   public void userIdOrAnonymousIdIsRequired() {
     final String exceptionMessage = "Either anonymousId or userId must be provided.";

--- a/analytics-core/src/test/java/com/segment/analytics/messages/TrackMessageTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/TrackMessageTest.java
@@ -1,6 +1,7 @@
 package com.segment.analytics.messages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
@@ -36,5 +37,31 @@ public class TrackMessageTest {
 
     assertThat(copy.event()).isEqualTo("event");
     assertThat(copy.properties()).isEqualTo(ImmutableMap.of("foo", "bar"));
+  }
+
+  @Test
+  public void userIdOrAnonymousIdIsRequired() {
+    final String exceptionMessage = "Either anonymousId or userId must be provided.";
+
+    try {
+      TrackMessage.builder("event").build();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(exceptionMessage);
+    }
+
+    try {
+      TrackMessage.builder("event").userId(null).anonymousId((String) null).build();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(exceptionMessage);
+    }
+
+    try {
+      TrackMessage.builder("event").userId("").anonymousId("").build();
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage(exceptionMessage);
+    }
   }
 }

--- a/analytics-core/src/test/java/com/segment/analytics/messages/TrackMessageTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/messages/TrackMessageTest.java
@@ -38,7 +38,7 @@ public class TrackMessageTest {
     assertThat(copy.event()).isEqualTo("event");
     assertThat(copy.properties()).isEqualTo(ImmutableMap.of("foo", "bar"));
   }
-
+  
   @Test
   public void userIdOrAnonymousIdIsRequired() {
     final String exceptionMessage = "Either anonymousId or userId must be provided.";
@@ -63,5 +63,13 @@ public class TrackMessageTest {
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessage(exceptionMessage);
     }
+
+    TrackMessage message = TrackMessage.builder("event").userId("theUserId").build();
+    assertThat(message.userId()).isEqualTo("theUserId");
+    assertThat(message.event()).isEqualTo("event");
+
+    message = TrackMessage.builder("event").anonymousId("theAnonymousId").build();
+    assertThat(message.anonymousId()).isEqualTo("theAnonymousId");
+    assertThat(message.event()).isEqualTo("event");
   }
 }


### PR DESCRIPTION
The Java SDK has a rule and corresponding unit tests that would throw if **either** `userId` or `anonymous` were null or empty strings. This was causing issues for Segment customers that needed to set an `anonymousId` and a null `userId` - the `userId` omission would always throw.

According to the Segment spec for [Identify calls](https://segment.com/docs/connections/spec/identify/#identities) and conventions used in [other SDKs](https://segment.com/docs/connections/sources/catalog/libraries/server/node/#identify), events must have either a `userId` or an `anonymousId`.

This PR aligns the Java SDK with the Segment spec and other SDKs:
- removes the individual null/empty checks for `userId` and `anonymousId`; the check will only be performed in MessageBuilder.build()
- changed the check in MessageBuilder.build():
  - include empty string as well as null
  - use IllegalArgumentException instead of IllegalStateException since the exception is based on input arguments
- removed individual null/empty checks for `userId` and `anonymousId` from MessageBuilderTest
- added `userIdOrAnonymousIdIsRequired()` tests to TrackMessageTest and IdentifyMessageTest