### PR TITLE
Bugfix for TLS version error (protocol not supported error)

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -9,15 +9,18 @@ import com.segment.analytics.internal.AnalyticsClient;
 import com.segment.analytics.internal.AnalyticsVersion;
 import com.segment.analytics.messages.Message;
 import com.segment.analytics.messages.MessageBuilder;
+import java.util.List;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import okhttp3.HttpUrl;
+import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
+import okhttp3.HttpUrl;
+import okhttp3.TlsVersion;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
@@ -145,6 +148,7 @@ public class Analytics {
     private long flushIntervalInMillis;
     private List<Callback> callbacks;
     private int queueCapacity;
+    private boolean forceTlsV1 = false;
 
     Builder(String writeKey) {
       if (writeKey == null || writeKey.trim().length() == 0) {
@@ -329,6 +333,12 @@ public class Analytics {
       return this;
     }
 
+    /** Specify if need TlsV1 */
+    public Builder forceTlsVersion1() {
+      forceTlsV1 = true;
+      return this;
+    }
+
     /** Create a {@link Analytics} client. */
     public Analytics build() {
       Gson gson =
@@ -400,12 +410,21 @@ public class Analytics {
 
       interceptor.setLevel(HttpLoggingInterceptor.Level.BASIC);
 
-      client =
+      OkHttpClient.Builder builder =
           client
               .newBuilder()
               .addInterceptor(new AnalyticsRequestInterceptor(writeKey, userAgent))
-              .addInterceptor(interceptor)
+              .addInterceptor(interceptor);
+
+      if (forceTlsV1) {
+        ConnectionSpec connectionSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                .tlsVersions(TlsVersion.TLS_1_0, TlsVersion.TLS_1_1, TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
               .build();
+
+        builder = builder.connectionSpecs(Arrays.asList(connectionSpec));
+      }
+
+      client = builder.build();
 
       Retrofit restAdapter =
           new Retrofit.Builder()

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -9,17 +9,17 @@ import com.segment.analytics.internal.AnalyticsClient;
 import com.segment.analytics.internal.AnalyticsVersion;
 import com.segment.analytics.messages.Message;
 import com.segment.analytics.messages.MessageBuilder;
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import okhttp3.ConnectionSpec;
-import okhttp3.OkHttpClient;
 import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
 import okhttp3.logging.HttpLoggingInterceptor;
 import retrofit2.Retrofit;
@@ -417,9 +417,11 @@ public class Analytics {
               .addInterceptor(interceptor);
 
       if (forceTlsV1) {
-        ConnectionSpec connectionSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                .tlsVersions(TlsVersion.TLS_1_0, TlsVersion.TLS_1_1, TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
-              .build();
+        ConnectionSpec connectionSpec =
+            new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+                .tlsVersions(
+                    TlsVersion.TLS_1_0, TlsVersion.TLS_1_1, TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
+                .build();
 
         builder = builder.connectionSpecs(Arrays.asList(connectionSpec));
       }

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -375,6 +374,12 @@ public class AnalyticsBuilderTest {
   @Test
   public void buildsWithValidCallback() {
     Analytics analytics = builder.callback(mock(Callback.class)).build();
+    assertThat(analytics).isNotNull();
+  }
+
+  @Test
+  public void buildsWithForceTlsV1() {
+    Analytics analytics = builder.forceTlsVersion1().build();
     assertThat(analytics).isNotNull();
   }
 

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
    Added a method to the Analytics Builder class forceTlsVersion1() - name subject to change
    Usage -
            Analytics.Builder builder = Analytics.builder("someKey");
            Analytics analytics = builder.userAgent("someUserAgent")
            .client(someClient)
            .endpoint("some endpoint")
            .anotherAlreadyExistingMethod(someParam)
            .forceTlsVersion1()
            .build();

    this new method forces the httpClient to be created using  ConnectionSpec of MODERN_TLS and including Tls Versions: TLS_1_0, TLS_1_1, TLS_1_2, TLS_1_3

    Also added a simple test case