### PR TITLE
fix: AnalyticsClient Looper won't start if isShutdown is true

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/internal/AnalyticsClient.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/AnalyticsClient.java
@@ -12,7 +12,6 @@ import com.segment.analytics.http.UploadResponse;
 import com.segment.analytics.messages.Batch;
 import com.segment.analytics.messages.Message;
 import com.segment.backo.Backo;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,340 +26,336 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import retrofit2.Call;
 import retrofit2.Response;
 
 public class AnalyticsClient {
-    private static final Map<String, ?> CONTEXT;
+  private static final Map<String, ?> CONTEXT;
 
-    static {
-        Map<String, String> library = new LinkedHashMap<>();
-        library.put("name", "analytics-java");
-        library.put("version", AnalyticsVersion.get());
-        Map<String, Object> context = new LinkedHashMap<>();
-        context.put("library", Collections.unmodifiableMap(library));
-        CONTEXT = Collections.unmodifiableMap(context);
+  static {
+    Map<String, String> library = new LinkedHashMap<>();
+    library.put("name", "analytics-java");
+    library.put("version", AnalyticsVersion.get());
+    Map<String, Object> context = new LinkedHashMap<>();
+    context.put("library", Collections.unmodifiableMap(library));
+    CONTEXT = Collections.unmodifiableMap(context);
+  }
+
+  private final BlockingQueue<Message> messageQueue;
+  private final SegmentService service;
+  private final int size;
+  private final int maximumRetries;
+  private final int maximumQueueByteSize;
+  private int currentQueueSizeInBytes;
+  private final Log log;
+  private final List<Callback> callbacks;
+  private final ExecutorService networkExecutor;
+  private final ExecutorService looperExecutor;
+  private final ScheduledExecutorService flushScheduler;
+  private final AtomicBoolean isShutDown;
+
+  public static AnalyticsClient create(
+      SegmentService segmentService,
+      int queueCapacity,
+      int flushQueueSize,
+      long flushIntervalInMillis,
+      int maximumRetries,
+      int maximumQueueSizeInBytes,
+      Log log,
+      ThreadFactory threadFactory,
+      ExecutorService networkExecutor,
+      List<Callback> callbacks) {
+    return new AnalyticsClient(
+        new LinkedBlockingQueue<Message>(queueCapacity),
+        segmentService,
+        flushQueueSize,
+        flushIntervalInMillis,
+        maximumRetries,
+        maximumQueueSizeInBytes,
+        log,
+        threadFactory,
+        networkExecutor,
+        callbacks,
+        new AtomicBoolean(false));
+  }
+
+  AnalyticsClient(
+      BlockingQueue<Message> messageQueue,
+      SegmentService service,
+      int maxQueueSize,
+      long flushIntervalInMillis,
+      int maximumRetries,
+      int maximumQueueSizeInBytes,
+      Log log,
+      ThreadFactory threadFactory,
+      ExecutorService networkExecutor,
+      List<Callback> callbacks,
+      AtomicBoolean isShutDown) {
+    this.messageQueue = messageQueue;
+    this.service = service;
+    this.size = maxQueueSize;
+    this.maximumRetries = maximumRetries;
+    this.maximumQueueByteSize = maximumQueueSizeInBytes;
+    this.log = log;
+    this.callbacks = callbacks;
+    this.looperExecutor = Executors.newSingleThreadExecutor(threadFactory);
+    this.networkExecutor = networkExecutor;
+    this.isShutDown = isShutDown;
+
+    this.currentQueueSizeInBytes = 0;
+
+    if (!isShutDown.get()) looperExecutor.submit(new Looper());
+
+    flushScheduler = Executors.newScheduledThreadPool(1, threadFactory);
+    flushScheduler.scheduleAtFixedRate(
+        new Runnable() {
+          @Override
+          public void run() {
+            flush();
+          }
+        },
+        flushIntervalInMillis,
+        flushIntervalInMillis,
+        TimeUnit.MILLISECONDS);
+  }
+
+  public int messageSizeInBytes(Message message) {
+    Gson gson = new Gson();
+    String stringifiedMessage = gson.toJson(message);
+    return stringifiedMessage.length();
+  }
+
+  private Boolean isBackPressuredAfterSize(int incomingSize) {
+    int POISON_BYTE_SIZE = messageSizeInBytes(FlushMessage.POISON);
+    int sizeAfterAdd = this.currentQueueSizeInBytes + incomingSize + POISON_BYTE_SIZE;
+    return sizeAfterAdd >= Math.min(this.maximumQueueByteSize, 1024 * 500);
+  }
+
+  public boolean offer(Message message) {
+    return messageQueue.offer(message);
+  }
+
+  public void enqueue(Message message) {
+    if (message != StopMessage.STOP && isShutDown.get()) {
+      log.print(ERROR, "Attempt to enqueue a message when shutdown has been called %s.", message);
+      return;
     }
 
-    private final BlockingQueue<Message> messageQueue;
-    private final SegmentService service;
-    private final int size;
-    private final int maximumRetries;
-    private final int maximumQueueByteSize;
-    private int currentQueueSizeInBytes;
-    private final Log log;
-    private final List<Callback> callbacks;
-    private final ExecutorService networkExecutor;
-    private final ExecutorService looperExecutor;
-    private final ScheduledExecutorService flushScheduler;
-    private final AtomicBoolean isShutDown;
+    try {
+      messageQueue.put(message);
 
-    public static AnalyticsClient create(
-            SegmentService segmentService,
-            int queueCapacity,
-            int flushQueueSize,
-            long flushIntervalInMillis,
-            int maximumRetries,
-            int maximumQueueSizeInBytes,
-            Log log,
-            ThreadFactory threadFactory,
-            ExecutorService networkExecutor,
-            List<Callback> callbacks) {
-        return new AnalyticsClient(
-                new LinkedBlockingQueue<Message>(queueCapacity),
-                segmentService,
-                flushQueueSize,
-                flushIntervalInMillis,
-                maximumRetries,
-                maximumQueueSizeInBytes,
-                log,
-                threadFactory,
-                networkExecutor,
-                callbacks,
-                new AtomicBoolean(false));
+      int tempSize = this.currentQueueSizeInBytes;
+      int messageByteSize = messageSizeInBytes(message);
+
+      if (isBackPressuredAfterSize(messageByteSize)) {
+        this.currentQueueSizeInBytes = messageByteSize;
+        messageQueue.put(FlushMessage.POISON);
+
+        log.print(VERBOSE, "Maximum storage size has been hit Flushing...");
+      } else {
+        this.currentQueueSizeInBytes += messageByteSize;
+      }
+    } catch (InterruptedException e) {
+      log.print(ERROR, e, "Interrupted while adding message %s.", message);
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  public void flush() {
+    if (!isShutDown.get()) {
+      enqueue(FlushMessage.POISON);
+    }
+  }
+
+  public void shutdown() {
+    if (isShutDown.compareAndSet(false, true)) {
+      final long start = System.currentTimeMillis();
+
+      // first let's tell the system to stop
+      enqueue(StopMessage.STOP);
+
+      // we can shutdown the flush scheduler without worrying
+      flushScheduler.shutdownNow();
+
+      shutdownAndWait(looperExecutor, "looper");
+      shutdownAndWait(networkExecutor, "network");
+
+      log.print(
+          VERBOSE, "Analytics client shut down in %s ms", (System.currentTimeMillis() - start));
+    }
+  }
+
+  public void shutdownAndWait(ExecutorService executor, String name) {
+    try {
+      executor.shutdown();
+      final boolean executorTerminated = executor.awaitTermination(1, TimeUnit.SECONDS);
+
+      log.print(
+          VERBOSE,
+          "%s executor %s.",
+          name,
+          executorTerminated ? "terminated normally" : "timed out");
+    } catch (InterruptedException e) {
+      log.print(ERROR, e, "Interrupted while stopping %s executor.", name);
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Looper runs on a background thread and takes messages from the queue. Once it collects enough
+   * messages, it triggers a flush.
+   */
+  class Looper implements Runnable {
+    private boolean stop;
+
+    public Looper() {
+      this.stop = false;
     }
 
-    AnalyticsClient(
-            BlockingQueue<Message> messageQueue,
-            SegmentService service,
-            int maxQueueSize,
-            long flushIntervalInMillis,
-            int maximumRetries,
-            int maximumQueueSizeInBytes,
-            Log log,
-            ThreadFactory threadFactory,
-            ExecutorService networkExecutor,
-            List<Callback> callbacks,
-            AtomicBoolean isShutDown) {
-        this.messageQueue = messageQueue;
-        this.service = service;
-        this.size = maxQueueSize;
-        this.maximumRetries = maximumRetries;
-        this.maximumQueueByteSize = maximumQueueSizeInBytes;
-        this.log = log;
-        this.callbacks = callbacks;
-        this.looperExecutor = Executors.newSingleThreadExecutor(threadFactory);
-        this.networkExecutor = networkExecutor;
-        this.isShutDown = isShutDown;
+    @Override
+    public void run() {
+      List<Message> messages = new ArrayList<>();
+      try {
+        while (!stop) {
+          Message message = messageQueue.take();
 
-        this.currentQueueSizeInBytes = 0;
-
-        if (!isShutDown.get())
-            looperExecutor.submit(new Looper());
-
-        flushScheduler = Executors.newScheduledThreadPool(1, threadFactory);
-        flushScheduler.scheduleAtFixedRate(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        flush();
-                    }
-                },
-                flushIntervalInMillis,
-                flushIntervalInMillis,
-                TimeUnit.MILLISECONDS);
-    }
-
-    public int messageSizeInBytes(Message message) {
-        Gson gson = new Gson();
-        String stringifiedMessage = gson.toJson(message);
-        return stringifiedMessage.length();
-    }
-
-    private Boolean isBackPressuredAfterSize(int incomingSize) {
-        int POISON_BYTE_SIZE = messageSizeInBytes(FlushMessage.POISON);
-        int sizeAfterAdd = this.currentQueueSizeInBytes + incomingSize + POISON_BYTE_SIZE;
-        return sizeAfterAdd >= Math.min(this.maximumQueueByteSize, 1024 * 500);
-    }
-
-    public boolean offer(Message message) {
-        return messageQueue.offer(message);
-    }
-
-    public void enqueue(Message message) {
-        if (message != StopMessage.STOP && isShutDown.get()) {
-            log.print(ERROR, "Attempt to enqueue a message when shutdown has been called %s.", message);
-            return;
-        }
-
-        try {
-            messageQueue.put(message);
-
-            int tempSize = this.currentQueueSizeInBytes;
-            int messageByteSize = messageSizeInBytes(message);
-
-            if (isBackPressuredAfterSize(messageByteSize)) {
-                this.currentQueueSizeInBytes = messageByteSize;
-                messageQueue.put(FlushMessage.POISON);
-
-                log.print(VERBOSE, "Maximum storage size has been hit Flushing...");
-            } else {
-                this.currentQueueSizeInBytes += messageByteSize;
+          if (message == StopMessage.STOP) {
+            log.print(VERBOSE, "Stopping the Looper");
+            stop = true;
+          } else if (message == FlushMessage.POISON) {
+            if (!messages.isEmpty()) {
+              log.print(VERBOSE, "Flushing messages.");
             }
-        } catch (InterruptedException e) {
-            log.print(ERROR, e, "Interrupted while adding message %s.", message);
-            Thread.currentThread().interrupt();
-        }
-    }
+          } else {
+            messages.add(message);
+          }
 
-    public void flush() {
-        if (!isShutDown.get()) {
-            enqueue(FlushMessage.POISON);
-        }
-    }
+          Boolean isBlockingSignal = message == FlushMessage.POISON || message == StopMessage.STOP;
+          Boolean isOverflow = messages.size() >= size;
 
-    public void shutdown() {
-        if (isShutDown.compareAndSet(false, true)) {
-            final long start = System.currentTimeMillis();
-
-            // first let's tell the system to stop
-            enqueue(StopMessage.STOP);
-
-            // we can shutdown the flush scheduler without worrying
-            flushScheduler.shutdownNow();
-
-            shutdownAndWait(looperExecutor, "looper");
-            shutdownAndWait(networkExecutor, "network");
-
+          if (!messages.isEmpty() && (isOverflow || isBlockingSignal)) {
+            Batch batch = Batch.create(CONTEXT, messages);
             log.print(
-                    VERBOSE, "Analytics client shut down in %s ms", (System.currentTimeMillis() - start));
+                VERBOSE,
+                "Batching %s message(s) into batch %s.",
+                messages.size(),
+                batch.sequence());
+            networkExecutor.submit(
+                BatchUploadTask.create(AnalyticsClient.this, batch, maximumRetries));
+            messages = new ArrayList<>();
+          }
         }
+      } catch (InterruptedException e) {
+        log.print(DEBUG, "Looper interrupted while polling for messages.");
+        Thread.currentThread().interrupt();
+      }
+      log.print(VERBOSE, "Looper stopped");
+    }
+  }
+
+  static class BatchUploadTask implements Runnable {
+    private static final Backo BACKO =
+        Backo.builder() //
+            .base(TimeUnit.SECONDS, 15) //
+            .cap(TimeUnit.HOURS, 1) //
+            .jitter(1) //
+            .build();
+
+    private final AnalyticsClient client;
+    private final Backo backo;
+    final Batch batch;
+    private final int maxRetries;
+
+    static BatchUploadTask create(AnalyticsClient client, Batch batch, int maxRetries) {
+      return new BatchUploadTask(client, BACKO, batch, maxRetries);
     }
 
-    public void shutdownAndWait(ExecutorService executor, String name) {
+    BatchUploadTask(AnalyticsClient client, Backo backo, Batch batch, int maxRetries) {
+      this.client = client;
+      this.batch = batch;
+      this.backo = backo;
+      this.maxRetries = maxRetries;
+    }
+
+    private void notifyCallbacksWithException(Batch batch, Exception exception) {
+      for (Message message : batch.batch()) {
+        for (Callback callback : client.callbacks) {
+          callback.failure(message, exception);
+        }
+      }
+    }
+
+    /** Returns {@code true} to indicate a batch should be retried. {@code false} otherwise. */
+    boolean upload() {
+      client.log.print(VERBOSE, "Uploading batch %s.", batch.sequence());
+
+      try {
+        Call<UploadResponse> call = client.service.upload(batch);
+        Response<UploadResponse> response = call.execute();
+
+        if (response.isSuccessful()) {
+          client.log.print(VERBOSE, "Uploaded batch %s.", batch.sequence());
+
+          for (Message message : batch.batch()) {
+            for (Callback callback : client.callbacks) {
+              callback.success(message);
+            }
+          }
+
+          return false;
+        }
+
+        int status = response.code();
+        if (is5xx(status)) {
+          client.log.print(
+              DEBUG, "Could not upload batch %s due to server error. Retrying.", batch.sequence());
+          return true;
+        } else if (status == 429) {
+          client.log.print(
+              DEBUG, "Could not upload batch %s due to rate limiting. Retrying.", batch.sequence());
+          return true;
+        }
+
+        client.log.print(DEBUG, "Could not upload batch %s. Giving up.", batch.sequence());
+        notifyCallbacksWithException(batch, new IOException(response.errorBody().string()));
+
+        return false;
+      } catch (IOException error) {
+        client.log.print(DEBUG, error, "Could not upload batch %s. Retrying.", batch.sequence());
+        notifyCallbacksWithException(batch, error);
+
+        return true;
+      } catch (Exception exception) {
+        client.log.print(DEBUG, "Could not upload batch %s. Giving up.", batch.sequence());
+
+        notifyCallbacksWithException(batch, exception);
+
+        return false;
+      }
+    }
+
+    @Override
+    public void run() {
+      int attempt = 0;
+      for (; attempt <= maxRetries; attempt++) {
+        boolean retry = upload();
+        if (!retry) return;
         try {
-            executor.shutdown();
-            final boolean executorTerminated = executor.awaitTermination(1, TimeUnit.SECONDS);
-
-            log.print(
-                    VERBOSE,
-                    "%s executor %s.",
-                    name,
-                    executorTerminated ? "terminated normally" : "timed out");
+          backo.sleep(attempt);
         } catch (InterruptedException e) {
-            log.print(ERROR, e, "Interrupted while stopping %s executor.", name);
-            Thread.currentThread().interrupt();
+          client.log.print(
+              DEBUG, "Thread interrupted while backing off for batch %s.", batch.sequence());
+          return;
         }
+      }
+
+      client.log.print(ERROR, "Could not upload batch %s. Retries exhausted.", batch.sequence());
+      notifyCallbacksWithException(
+          batch, new IOException(Integer.toString(attempt) + " retries exhausted"));
     }
 
-    /**
-     * Looper runs on a background thread and takes messages from the queue. Once it collects enough
-     * messages, it triggers a flush.
-     */
-    class Looper implements Runnable {
-        private boolean stop;
-
-        public Looper() {
-            this.stop = false;
-        }
-
-        @Override
-        public void run() {
-            List<Message> messages = new ArrayList<>();
-            try {
-                while (!stop) {
-                    Message message = messageQueue.take();
-
-                    if (message == StopMessage.STOP) {
-                        log.print(VERBOSE, "Stopping the Looper");
-                        stop = true;
-                    } else if (message == FlushMessage.POISON) {
-                        if (!messages.isEmpty()) {
-                            log.print(VERBOSE, "Flushing messages.");
-                        }
-                    } else {
-                        messages.add(message);
-                    }
-
-                    Boolean isBlockingSignal = message == FlushMessage.POISON || message == StopMessage.STOP;
-                    Boolean isOverflow = messages.size() >= size;
-
-                    if (!messages.isEmpty() && (isOverflow || isBlockingSignal)) {
-                        Batch batch = Batch.create(CONTEXT, messages);
-                        log.print(
-                                VERBOSE,
-                                "Batching %s message(s) into batch %s.",
-                                messages.size(),
-                                batch.sequence());
-                        networkExecutor.submit(
-                                BatchUploadTask.create(AnalyticsClient.this, batch, maximumRetries));
-                        messages = new ArrayList<>();
-                    }
-                }
-            } catch (InterruptedException e) {
-                log.print(DEBUG, "Looper interrupted while polling for messages.");
-                Thread.currentThread().interrupt();
-            }
-            log.print(VERBOSE, "Looper stopped");
-        }
+    private static boolean is5xx(int status) {
+      return status >= 500 && status < 600;
     }
-
-    static class BatchUploadTask implements Runnable {
-        private static final Backo BACKO =
-                Backo.builder() //
-                        .base(TimeUnit.SECONDS, 15) //
-                        .cap(TimeUnit.HOURS, 1) //
-                        .jitter(1) //
-                        .build();
-
-        private final AnalyticsClient client;
-        private final Backo backo;
-        final Batch batch;
-        private final int maxRetries;
-
-        static BatchUploadTask create(AnalyticsClient client, Batch batch, int maxRetries) {
-            return new BatchUploadTask(client, BACKO, batch, maxRetries);
-        }
-
-        BatchUploadTask(AnalyticsClient client, Backo backo, Batch batch, int maxRetries) {
-            this.client = client;
-            this.batch = batch;
-            this.backo = backo;
-            this.maxRetries = maxRetries;
-        }
-
-        private void notifyCallbacksWithException(Batch batch, Exception exception) {
-            for (Message message : batch.batch()) {
-                for (Callback callback : client.callbacks) {
-                    callback.failure(message, exception);
-                }
-            }
-        }
-
-        /**
-         * Returns {@code true} to indicate a batch should be retried. {@code false} otherwise.
-         */
-        boolean upload() {
-            client.log.print(VERBOSE, "Uploading batch %s.", batch.sequence());
-
-            try {
-                Call<UploadResponse> call = client.service.upload(batch);
-                Response<UploadResponse> response = call.execute();
-
-                if (response.isSuccessful()) {
-                    client.log.print(VERBOSE, "Uploaded batch %s.", batch.sequence());
-
-                    for (Message message : batch.batch()) {
-                        for (Callback callback : client.callbacks) {
-                            callback.success(message);
-                        }
-                    }
-
-                    return false;
-                }
-
-                int status = response.code();
-                if (is5xx(status)) {
-                    client.log.print(
-                            DEBUG, "Could not upload batch %s due to server error. Retrying.", batch.sequence());
-                    return true;
-                } else if (status == 429) {
-                    client.log.print(
-                            DEBUG, "Could not upload batch %s due to rate limiting. Retrying.", batch.sequence());
-                    return true;
-                }
-
-                client.log.print(DEBUG, "Could not upload batch %s. Giving up.", batch.sequence());
-                notifyCallbacksWithException(batch, new IOException(response.errorBody().string()));
-
-                return false;
-            } catch (IOException error) {
-                client.log.print(DEBUG, error, "Could not upload batch %s. Retrying.", batch.sequence());
-                notifyCallbacksWithException(batch, error);
-
-                return true;
-            } catch (Exception exception) {
-                client.log.print(DEBUG, "Could not upload batch %s. Giving up.", batch.sequence());
-
-                notifyCallbacksWithException(batch, exception);
-
-                return false;
-            }
-        }
-
-        @Override
-        public void run() {
-            int attempt = 0;
-            for (; attempt <= maxRetries; attempt++) {
-                boolean retry = upload();
-                if (!retry) return;
-                try {
-                    backo.sleep(attempt);
-                } catch (InterruptedException e) {
-                    client.log.print(
-                            DEBUG, "Thread interrupted while backing off for batch %s.", batch.sequence());
-                    return;
-                }
-            }
-
-            client.log.print(ERROR, "Could not upload batch %s. Retries exhausted.", batch.sequence());
-            notifyCallbacksWithException(
-                    batch, new IOException(Integer.toString(attempt) + " retries exhausted"));
-        }
-
-        private static boolean is5xx(int status) {
-            return status >= 500 && status < 600;
-        }
-    }
+  }
 }

--- a/analytics/src/main/java/com/segment/analytics/internal/AnalyticsClient.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/AnalyticsClient.java
@@ -12,6 +12,7 @@ import com.segment.analytics.http.UploadResponse;
 import com.segment.analytics.messages.Batch;
 import com.segment.analytics.messages.Message;
 import com.segment.backo.Backo;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,337 +27,340 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import retrofit2.Call;
 import retrofit2.Response;
 
 public class AnalyticsClient {
-  private static final Map<String, ?> CONTEXT;
+    private static final Map<String, ?> CONTEXT;
 
-  static {
-    Map<String, String> library = new LinkedHashMap<>();
-    library.put("name", "analytics-java");
-    library.put("version", AnalyticsVersion.get());
-    Map<String, Object> context = new LinkedHashMap<>();
-    context.put("library", Collections.unmodifiableMap(library));
-    CONTEXT = Collections.unmodifiableMap(context);
-  }
-
-  private final BlockingQueue<Message> messageQueue;
-  private final SegmentService service;
-  private final int size;
-  private final int maximumRetries;
-  private final int maximumQueueByteSize;
-  private int currentQueueSizeInBytes;
-  private final Log log;
-  private final List<Callback> callbacks;
-  private final ExecutorService networkExecutor;
-  private final ExecutorService looperExecutor;
-  private final ScheduledExecutorService flushScheduler;
-  private final AtomicBoolean isShutDown;
-
-  public static AnalyticsClient create(
-      SegmentService segmentService,
-      int queueCapacity,
-      int flushQueueSize,
-      long flushIntervalInMillis,
-      int maximumRetries,
-      int maximumQueueSizeInBytes,
-      Log log,
-      ThreadFactory threadFactory,
-      ExecutorService networkExecutor,
-      List<Callback> callbacks) {
-    return new AnalyticsClient(
-        new LinkedBlockingQueue<Message>(queueCapacity),
-        segmentService,
-        flushQueueSize,
-        flushIntervalInMillis,
-        maximumRetries,
-        maximumQueueSizeInBytes,
-        log,
-        threadFactory,
-        networkExecutor,
-        callbacks,
-        new AtomicBoolean(false));
-  }
-
-  AnalyticsClient(
-      BlockingQueue<Message> messageQueue,
-      SegmentService service,
-      int maxQueueSize,
-      long flushIntervalInMillis,
-      int maximumRetries,
-      int maximumQueueSizeInBytes,
-      Log log,
-      ThreadFactory threadFactory,
-      ExecutorService networkExecutor,
-      List<Callback> callbacks,
-      AtomicBoolean isShutDown) {
-    this.messageQueue = messageQueue;
-    this.service = service;
-    this.size = maxQueueSize;
-    this.maximumRetries = maximumRetries;
-    this.maximumQueueByteSize = maximumQueueSizeInBytes;
-    this.log = log;
-    this.callbacks = callbacks;
-    this.looperExecutor = Executors.newSingleThreadExecutor(threadFactory);
-    this.networkExecutor = networkExecutor;
-    this.isShutDown = isShutDown;
-
-    this.currentQueueSizeInBytes = 0;
-
-    if(!isShutDown.get())
-        looperExecutor.submit(new Looper());
-
-    flushScheduler = Executors.newScheduledThreadPool(1, threadFactory);
-    flushScheduler.scheduleAtFixedRate(
-        new Runnable() {
-          @Override
-          public void run() {
-            flush();
-          }
-        },
-        flushIntervalInMillis,
-        flushIntervalInMillis,
-        TimeUnit.MILLISECONDS);
-  }
-
-  public int messageSizeInBytes(Message message) {
-    Gson gson = new Gson();
-    String stringifiedMessage = gson.toJson(message);
-    return stringifiedMessage.length();
-  }
-
-  private Boolean isBackPressuredAfterSize(int incomingSize) {
-    int POISON_BYTE_SIZE = messageSizeInBytes(FlushMessage.POISON);
-    int sizeAfterAdd = this.currentQueueSizeInBytes + incomingSize + POISON_BYTE_SIZE;
-    return sizeAfterAdd >= Math.min(this.maximumQueueByteSize, 1024 * 500);
-  }
-
-  public boolean offer(Message message) {
-    return messageQueue.offer(message);
-  }
-
-  public void enqueue(Message message) {
-    if (message != StopMessage.STOP && isShutDown.get()) {
-      log.print(ERROR, "Attempt to enqueue a message when shutdown has been called %s.", message);
-      return;
+    static {
+        Map<String, String> library = new LinkedHashMap<>();
+        library.put("name", "analytics-java");
+        library.put("version", AnalyticsVersion.get());
+        Map<String, Object> context = new LinkedHashMap<>();
+        context.put("library", Collections.unmodifiableMap(library));
+        CONTEXT = Collections.unmodifiableMap(context);
     }
 
-    try {
-      messageQueue.put(message);
+    private final BlockingQueue<Message> messageQueue;
+    private final SegmentService service;
+    private final int size;
+    private final int maximumRetries;
+    private final int maximumQueueByteSize;
+    private int currentQueueSizeInBytes;
+    private final Log log;
+    private final List<Callback> callbacks;
+    private final ExecutorService networkExecutor;
+    private final ExecutorService looperExecutor;
+    private final ScheduledExecutorService flushScheduler;
+    private final AtomicBoolean isShutDown;
 
-      int tempSize = this.currentQueueSizeInBytes;
-      int messageByteSize = messageSizeInBytes(message);
-
-      if (isBackPressuredAfterSize(messageByteSize)) {
-        this.currentQueueSizeInBytes = messageByteSize;
-        messageQueue.put(FlushMessage.POISON);
-
-        log.print(VERBOSE, "Maximum storage size has been hit Flushing...");
-      } else {
-        this.currentQueueSizeInBytes += messageByteSize;
-      }
-    } catch (InterruptedException e) {
-      log.print(ERROR, e, "Interrupted while adding message %s.", message);
-      Thread.currentThread().interrupt();
-    }
-  }
-
-  public void flush() {
-    if (!isShutDown.get()) {
-      enqueue(FlushMessage.POISON);
-    }
-  }
-
-  public void shutdown() {
-    if (isShutDown.compareAndSet(false, true)) {
-      final long start = System.currentTimeMillis();
-
-      // first let's tell the system to stop
-      enqueue(StopMessage.STOP);
-
-      // we can shutdown the flush scheduler without worrying
-      flushScheduler.shutdownNow();
-
-      shutdownAndWait(looperExecutor, "looper");
-      shutdownAndWait(networkExecutor, "network");
-
-      log.print(
-          VERBOSE, "Analytics client shut down in %s ms", (System.currentTimeMillis() - start));
-    }
-  }
-
-  public void shutdownAndWait(ExecutorService executor, String name) {
-    try {
-      executor.shutdown();
-      final boolean executorTerminated = executor.awaitTermination(1, TimeUnit.SECONDS);
-
-      log.print(
-          VERBOSE,
-          "%s executor %s.",
-          name,
-          executorTerminated ? "terminated normally" : "timed out");
-    } catch (InterruptedException e) {
-      log.print(ERROR, e, "Interrupted while stopping %s executor.", name);
-      Thread.currentThread().interrupt();
-    }
-  }
-
-  /**
-   * Looper runs on a background thread and takes messages from the queue. Once it collects enough
-   * messages, it triggers a flush.
-   */
-  class Looper implements Runnable {
-    private boolean stop;
-
-    public Looper() {
-      this.stop = false;
+    public static AnalyticsClient create(
+            SegmentService segmentService,
+            int queueCapacity,
+            int flushQueueSize,
+            long flushIntervalInMillis,
+            int maximumRetries,
+            int maximumQueueSizeInBytes,
+            Log log,
+            ThreadFactory threadFactory,
+            ExecutorService networkExecutor,
+            List<Callback> callbacks) {
+        return new AnalyticsClient(
+                new LinkedBlockingQueue<Message>(queueCapacity),
+                segmentService,
+                flushQueueSize,
+                flushIntervalInMillis,
+                maximumRetries,
+                maximumQueueSizeInBytes,
+                log,
+                threadFactory,
+                networkExecutor,
+                callbacks,
+                new AtomicBoolean(false));
     }
 
-    @Override
-    public void run() {
-      List<Message> messages = new ArrayList<>();
-      try {
-        while (!stop) {
-          Message message = messageQueue.take();
+    AnalyticsClient(
+            BlockingQueue<Message> messageQueue,
+            SegmentService service,
+            int maxQueueSize,
+            long flushIntervalInMillis,
+            int maximumRetries,
+            int maximumQueueSizeInBytes,
+            Log log,
+            ThreadFactory threadFactory,
+            ExecutorService networkExecutor,
+            List<Callback> callbacks,
+            AtomicBoolean isShutDown) {
+        this.messageQueue = messageQueue;
+        this.service = service;
+        this.size = maxQueueSize;
+        this.maximumRetries = maximumRetries;
+        this.maximumQueueByteSize = maximumQueueSizeInBytes;
+        this.log = log;
+        this.callbacks = callbacks;
+        this.looperExecutor = Executors.newSingleThreadExecutor(threadFactory);
+        this.networkExecutor = networkExecutor;
+        this.isShutDown = isShutDown;
 
-          if (message == StopMessage.STOP) {
-            log.print(VERBOSE, "Stopping the Looper");
-            stop = true;
-          } else if (message == FlushMessage.POISON) {
-            if (!messages.isEmpty()) {
-              log.print(VERBOSE, "Flushing messages.");
-            }
-          } else {
-            messages.add(message);
-          }
+        this.currentQueueSizeInBytes = 0;
 
-          Boolean isBlockingSignal = message == FlushMessage.POISON || message == StopMessage.STOP;
-          Boolean isOverflow = messages.size() >= size;
+        if (!isShutDown.get())
+            looperExecutor.submit(new Looper());
 
-          if (!messages.isEmpty() && (isOverflow || isBlockingSignal)) {
-            Batch batch = Batch.create(CONTEXT, messages);
-            log.print(
-                VERBOSE,
-                "Batching %s message(s) into batch %s.",
-                messages.size(),
-                batch.sequence());
-            networkExecutor.submit(
-                BatchUploadTask.create(AnalyticsClient.this, batch, maximumRetries));
-            messages = new ArrayList<>();
-          }
-        }
-      } catch (InterruptedException e) {
-        log.print(DEBUG, "Looper interrupted while polling for messages.");
-        Thread.currentThread().interrupt();
-      }
-      log.print(VERBOSE, "Looper stopped");
-    }
-  }
-
-  static class BatchUploadTask implements Runnable {
-    private static final Backo BACKO =
-        Backo.builder() //
-            .base(TimeUnit.SECONDS, 15) //
-            .cap(TimeUnit.HOURS, 1) //
-            .jitter(1) //
-            .build();
-
-    private final AnalyticsClient client;
-    private final Backo backo;
-    final Batch batch;
-    private final int maxRetries;
-
-    static BatchUploadTask create(AnalyticsClient client, Batch batch, int maxRetries) {
-      return new BatchUploadTask(client, BACKO, batch, maxRetries);
+        flushScheduler = Executors.newScheduledThreadPool(1, threadFactory);
+        flushScheduler.scheduleAtFixedRate(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        flush();
+                    }
+                },
+                flushIntervalInMillis,
+                flushIntervalInMillis,
+                TimeUnit.MILLISECONDS);
     }
 
-    BatchUploadTask(AnalyticsClient client, Backo backo, Batch batch, int maxRetries) {
-      this.client = client;
-      this.batch = batch;
-      this.backo = backo;
-      this.maxRetries = maxRetries;
+    public int messageSizeInBytes(Message message) {
+        Gson gson = new Gson();
+        String stringifiedMessage = gson.toJson(message);
+        return stringifiedMessage.length();
     }
 
-    private void notifyCallbacksWithException(Batch batch, Exception exception) {
-      for (Message message : batch.batch()) {
-        for (Callback callback : client.callbacks) {
-          callback.failure(message, exception);
-        }
-      }
+    private Boolean isBackPressuredAfterSize(int incomingSize) {
+        int POISON_BYTE_SIZE = messageSizeInBytes(FlushMessage.POISON);
+        int sizeAfterAdd = this.currentQueueSizeInBytes + incomingSize + POISON_BYTE_SIZE;
+        return sizeAfterAdd >= Math.min(this.maximumQueueByteSize, 1024 * 500);
     }
 
-    /** Returns {@code true} to indicate a batch should be retried. {@code false} otherwise. */
-    boolean upload() {
-      client.log.print(VERBOSE, "Uploading batch %s.", batch.sequence());
+    public boolean offer(Message message) {
+        return messageQueue.offer(message);
+    }
 
-      try {
-        Call<UploadResponse> call = client.service.upload(batch);
-        Response<UploadResponse> response = call.execute();
-
-        if (response.isSuccessful()) {
-          client.log.print(VERBOSE, "Uploaded batch %s.", batch.sequence());
-
-          for (Message message : batch.batch()) {
-            for (Callback callback : client.callbacks) {
-              callback.success(message);
-            }
-          }
-
-          return false;
+    public void enqueue(Message message) {
+        if (message != StopMessage.STOP && isShutDown.get()) {
+            log.print(ERROR, "Attempt to enqueue a message when shutdown has been called %s.", message);
+            return;
         }
 
-        int status = response.code();
-        if (is5xx(status)) {
-          client.log.print(
-              DEBUG, "Could not upload batch %s due to server error. Retrying.", batch.sequence());
-          return true;
-        } else if (status == 429) {
-          client.log.print(
-              DEBUG, "Could not upload batch %s due to rate limiting. Retrying.", batch.sequence());
-          return true;
-        }
-
-        client.log.print(DEBUG, "Could not upload batch %s. Giving up.", batch.sequence());
-        notifyCallbacksWithException(batch, new IOException(response.errorBody().string()));
-
-        return false;
-      } catch (IOException error) {
-        client.log.print(DEBUG, error, "Could not upload batch %s. Retrying.", batch.sequence());
-        notifyCallbacksWithException(batch, error);
-
-        return true;
-      } catch (Exception exception) {
-        client.log.print(DEBUG, "Could not upload batch %s. Giving up.", batch.sequence());
-
-        notifyCallbacksWithException(batch, exception);
-
-        return false;
-      }
-    }
-
-    @Override
-    public void run() {
-      int attempt = 0;
-      for (; attempt <= maxRetries; attempt++) {
-        boolean retry = upload();
-        if (!retry) return;
         try {
-          backo.sleep(attempt);
+            messageQueue.put(message);
+
+            int tempSize = this.currentQueueSizeInBytes;
+            int messageByteSize = messageSizeInBytes(message);
+
+            if (isBackPressuredAfterSize(messageByteSize)) {
+                this.currentQueueSizeInBytes = messageByteSize;
+                messageQueue.put(FlushMessage.POISON);
+
+                log.print(VERBOSE, "Maximum storage size has been hit Flushing...");
+            } else {
+                this.currentQueueSizeInBytes += messageByteSize;
+            }
         } catch (InterruptedException e) {
-          client.log.print(
-              DEBUG, "Thread interrupted while backing off for batch %s.", batch.sequence());
-          return;
+            log.print(ERROR, e, "Interrupted while adding message %s.", message);
+            Thread.currentThread().interrupt();
         }
-      }
-
-      client.log.print(ERROR, "Could not upload batch %s. Retries exhausted.", batch.sequence());
-      notifyCallbacksWithException(
-          batch, new IOException(Integer.toString(attempt) + " retries exhausted"));
     }
 
-    private static boolean is5xx(int status) {
-      return status >= 500 && status < 600;
+    public void flush() {
+        if (!isShutDown.get()) {
+            enqueue(FlushMessage.POISON);
+        }
     }
-  }
+
+    public void shutdown() {
+        if (isShutDown.compareAndSet(false, true)) {
+            final long start = System.currentTimeMillis();
+
+            // first let's tell the system to stop
+            enqueue(StopMessage.STOP);
+
+            // we can shutdown the flush scheduler without worrying
+            flushScheduler.shutdownNow();
+
+            shutdownAndWait(looperExecutor, "looper");
+            shutdownAndWait(networkExecutor, "network");
+
+            log.print(
+                    VERBOSE, "Analytics client shut down in %s ms", (System.currentTimeMillis() - start));
+        }
+    }
+
+    public void shutdownAndWait(ExecutorService executor, String name) {
+        try {
+            executor.shutdown();
+            final boolean executorTerminated = executor.awaitTermination(1, TimeUnit.SECONDS);
+
+            log.print(
+                    VERBOSE,
+                    "%s executor %s.",
+                    name,
+                    executorTerminated ? "terminated normally" : "timed out");
+        } catch (InterruptedException e) {
+            log.print(ERROR, e, "Interrupted while stopping %s executor.", name);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Looper runs on a background thread and takes messages from the queue. Once it collects enough
+     * messages, it triggers a flush.
+     */
+    class Looper implements Runnable {
+        private boolean stop;
+
+        public Looper() {
+            this.stop = false;
+        }
+
+        @Override
+        public void run() {
+            List<Message> messages = new ArrayList<>();
+            try {
+                while (!stop) {
+                    Message message = messageQueue.take();
+
+                    if (message == StopMessage.STOP) {
+                        log.print(VERBOSE, "Stopping the Looper");
+                        stop = true;
+                    } else if (message == FlushMessage.POISON) {
+                        if (!messages.isEmpty()) {
+                            log.print(VERBOSE, "Flushing messages.");
+                        }
+                    } else {
+                        messages.add(message);
+                    }
+
+                    Boolean isBlockingSignal = message == FlushMessage.POISON || message == StopMessage.STOP;
+                    Boolean isOverflow = messages.size() >= size;
+
+                    if (!messages.isEmpty() && (isOverflow || isBlockingSignal)) {
+                        Batch batch = Batch.create(CONTEXT, messages);
+                        log.print(
+                                VERBOSE,
+                                "Batching %s message(s) into batch %s.",
+                                messages.size(),
+                                batch.sequence());
+                        networkExecutor.submit(
+                                BatchUploadTask.create(AnalyticsClient.this, batch, maximumRetries));
+                        messages = new ArrayList<>();
+                    }
+                }
+            } catch (InterruptedException e) {
+                log.print(DEBUG, "Looper interrupted while polling for messages.");
+                Thread.currentThread().interrupt();
+            }
+            log.print(VERBOSE, "Looper stopped");
+        }
+    }
+
+    static class BatchUploadTask implements Runnable {
+        private static final Backo BACKO =
+                Backo.builder() //
+                        .base(TimeUnit.SECONDS, 15) //
+                        .cap(TimeUnit.HOURS, 1) //
+                        .jitter(1) //
+                        .build();
+
+        private final AnalyticsClient client;
+        private final Backo backo;
+        final Batch batch;
+        private final int maxRetries;
+
+        static BatchUploadTask create(AnalyticsClient client, Batch batch, int maxRetries) {
+            return new BatchUploadTask(client, BACKO, batch, maxRetries);
+        }
+
+        BatchUploadTask(AnalyticsClient client, Backo backo, Batch batch, int maxRetries) {
+            this.client = client;
+            this.batch = batch;
+            this.backo = backo;
+            this.maxRetries = maxRetries;
+        }
+
+        private void notifyCallbacksWithException(Batch batch, Exception exception) {
+            for (Message message : batch.batch()) {
+                for (Callback callback : client.callbacks) {
+                    callback.failure(message, exception);
+                }
+            }
+        }
+
+        /**
+         * Returns {@code true} to indicate a batch should be retried. {@code false} otherwise.
+         */
+        boolean upload() {
+            client.log.print(VERBOSE, "Uploading batch %s.", batch.sequence());
+
+            try {
+                Call<UploadResponse> call = client.service.upload(batch);
+                Response<UploadResponse> response = call.execute();
+
+                if (response.isSuccessful()) {
+                    client.log.print(VERBOSE, "Uploaded batch %s.", batch.sequence());
+
+                    for (Message message : batch.batch()) {
+                        for (Callback callback : client.callbacks) {
+                            callback.success(message);
+                        }
+                    }
+
+                    return false;
+                }
+
+                int status = response.code();
+                if (is5xx(status)) {
+                    client.log.print(
+                            DEBUG, "Could not upload batch %s due to server error. Retrying.", batch.sequence());
+                    return true;
+                } else if (status == 429) {
+                    client.log.print(
+                            DEBUG, "Could not upload batch %s due to rate limiting. Retrying.", batch.sequence());
+                    return true;
+                }
+
+                client.log.print(DEBUG, "Could not upload batch %s. Giving up.", batch.sequence());
+                notifyCallbacksWithException(batch, new IOException(response.errorBody().string()));
+
+                return false;
+            } catch (IOException error) {
+                client.log.print(DEBUG, error, "Could not upload batch %s. Retrying.", batch.sequence());
+                notifyCallbacksWithException(batch, error);
+
+                return true;
+            } catch (Exception exception) {
+                client.log.print(DEBUG, "Could not upload batch %s. Giving up.", batch.sequence());
+
+                notifyCallbacksWithException(batch, exception);
+
+                return false;
+            }
+        }
+
+        @Override
+        public void run() {
+            int attempt = 0;
+            for (; attempt <= maxRetries; attempt++) {
+                boolean retry = upload();
+                if (!retry) return;
+                try {
+                    backo.sleep(attempt);
+                } catch (InterruptedException e) {
+                    client.log.print(
+                            DEBUG, "Thread interrupted while backing off for batch %s.", batch.sequence());
+                    return;
+                }
+            }
+
+            client.log.print(ERROR, "Could not upload batch %s. Retries exhausted.", batch.sequence());
+            notifyCallbacksWithException(
+                    batch, new IOException(Integer.toString(attempt) + " retries exhausted"));
+        }
+
+        private static boolean is5xx(int status) {
+            return status >= 500 && status < 600;
+        }
+    }
 }

--- a/analytics/src/main/java/com/segment/analytics/internal/AnalyticsClient.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/AnalyticsClient.java
@@ -104,7 +104,8 @@ public class AnalyticsClient {
 
     this.currentQueueSizeInBytes = 0;
 
-    looperExecutor.submit(new Looper());
+    if(!isShutDown.get())
+        looperExecutor.submit(new Looper());
 
     flushScheduler = Executors.newScheduledThreadPool(1, threadFactory);
     flushScheduler.scheduleAtFixedRate(

--- a/analytics/src/test/java/com/segment/analytics/internal/AnalyticsClientTest.java
+++ b/analytics/src/test/java/com/segment/analytics/internal/AnalyticsClientTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/analytics/src/test/java/com/segment/analytics/internal/AnalyticsClientTest.java
+++ b/analytics/src/test/java/com/segment/analytics/internal/AnalyticsClientTest.java
@@ -6,15 +6,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import com.segment.analytics.Callback;
 import com.segment.analytics.Log;
@@ -47,6 +40,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import retrofit2.Call;
@@ -65,7 +59,7 @@ public class AnalyticsClientTest {
   Log log = Log.NONE;
 
   ThreadFactory threadFactory;
-  @Mock BlockingQueue<Message> messageQueue;
+  @Spy LinkedBlockingQueue<Message> messageQueue;
   @Mock SegmentService segmentService;
   @Mock ExecutorService networkExecutor;
   @Mock Callback callback;
@@ -75,10 +69,10 @@ public class AnalyticsClientTest {
 
   @Before
   public void setUp() {
-    initMocks(this);
+    openMocks(this);
 
     isShutDown = new AtomicBoolean(false);
-    messageQueue = spy(new LinkedBlockingQueue<Message>());
+
     threadFactory = Executors.defaultThreadFactory();
   }
 
@@ -534,7 +528,7 @@ public class AnalyticsClientTest {
     client.shutdown();
 
     verify(messageQueue, times(0)).put(any(Message.class));
-    verifyZeroInteractions(networkExecutor, callback, segmentService);
+    verifyNoInteractions(networkExecutor, callback, segmentService);
   }
 
   @Test


### PR DESCRIPTION
AnalyticsClient was starting a looper even if isShutdown was true when initialising.
In that case messages submitted to Analytics were flushed even if AnalyticsClient was initialised with isShutdown as true.