### PR TITLE
Update dependabot libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,24 +28,24 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>8</java.version>
-    <kotlin.version>1.6.21</kotlin.version>
-    <spotless.version>2.22.1</spotless.version>
+    <kotlin.version>1.7.0</kotlin.version>
+    <spotless.version>2.23.0</spotless.version>
     <retrofit.version>2.9.0</retrofit.version>
     <auto.version>1.9</auto.version>
 
     <findbugs.version>3.0.1</findbugs.version>
     <gson.version>2.9.0</gson.version>
-    <okhttp.version>4.9.3</okhttp.version>
+    <okhttp.version>4.10.0</okhttp.version>
     <logging.version>4.10.0</logging.version>
     <guava.version>31.1-jre</guava.version>
     <backo.version>1.0.0</backo.version>
-    <spring.boot.version>2.6.6</spring.boot.version>
+    <spring.boot.version>2.7.1</spring.boot.version>
     <docopt.version>0.6.0.20150202</docopt.version>
 
     <!-- Test Dependencies -->
     <junit.version>4.13.2</junit.version>
     <burst.version>1.2.0</burst.version>
-    <mockito.version>4.4.0</mockito.version>
+    <mockito.version>4.6.1</mockito.version>
     <assertj.version>3.23.1</assertj.version>
   </properties>
 


### PR DESCRIPTION
Bump spotless-maven-plugin from 2.22.1 to 2.23.0  
Bump okhttp from 4.9.3 to 4.10.0  
Bump kotlin.version from 1.6.21 to 1.7.0
Bump spring-boot-autoconfigure from 2.6.6 to 2.7.1
Bump mockito-core from 4.4.0 to 4.6.1