### PR TITLE
Flush message queue instead of discarding them on shutdown

### DIFF
--- a/analytics-spring-boot-starter/src/main/java/com/segment/analytics/autoconfigure/SegmentAnalyticsAutoConfiguration.java
+++ b/analytics-spring-boot-starter/src/main/java/com/segment/analytics/autoconfigure/SegmentAnalyticsAutoConfiguration.java
@@ -19,7 +19,7 @@ public class SegmentAnalyticsAutoConfiguration {
 
   @Autowired private SegmentProperties properties;
 
-  @Bean
+  @Bean(destroyMethod = "flush")
   public Analytics segmentAnalytics() {
     return Analytics.builder(properties.getWriteKey()).build();
   }


### PR DESCRIPTION
The default `destroyMethod` for a Bean is inferred, and uses the `close` or `shutdown` method on the object.

But since the `shutdown` method of the analytics class stops processing of messages, there's a chance that this would discard messages.

By calling `flush` it should be able to process the messages before shutdown.

Even better might be to implement the blocking flush for the spring boot starter? (https://github.com/segmentio/analytics-java/blob/master/analytics-sample/src/main/java/sample/BlockingFlush.java)

Let me know what you think!