### PR TITLE
Add customizer interface for spring boot integration

### DIFF
--- a/analytics-spring-boot-starter/README.adoc
+++ b/analytics-spring-boot-starter/README.adoc
@@ -25,3 +25,17 @@ In your Spring Boot configuration (`application.properties`, environment, or
 similar), provide the property `segment.analytics.writeKey`. The
 autoconfiguration will register an `Analytics` bean in the Spring context
 ready for use.
+
+=== Customization
+
+To customize the `Analytics` client you can define a `SegmentAnalyticsCustomizer` bean,
+which receives the builder instance.
+
+For example if you want to use a regional endpoint you can define a customizer like so:
+
+```java
+@Bean
+SegmentAnalyticsCustomizer segmentAnalyticsCustomizer() {
+    return builder -> builder.endpoint("events.eu1.segmentapis.com");
+}
+```

--- a/analytics-spring-boot-starter/src/main/java/com/segment/analytics/autoconfigure/SegmentAnalyticsAutoConfiguration.java
+++ b/analytics-spring-boot-starter/src/main/java/com/segment/analytics/autoconfigure/SegmentAnalyticsAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.segment.analytics.autoconfigure;
 
 import com.segment.analytics.Analytics;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -20,7 +21,9 @@ public class SegmentAnalyticsAutoConfiguration {
   @Autowired private SegmentProperties properties;
 
   @Bean
-  public Analytics segmentAnalytics() {
-    return Analytics.builder(properties.getWriteKey()).build();
+  public Analytics segmentAnalytics(ObjectProvider<SegmentAnalyticsCustomizer> customizerProvider) {
+    Analytics.Builder builder = Analytics.builder(properties.getWriteKey());
+    customizerProvider.orderedStream().forEach((customizer) -> customizer.customize(builder));
+    return builder.build();
   }
 }

--- a/analytics-spring-boot-starter/src/main/java/com/segment/analytics/autoconfigure/SegmentAnalyticsCustomizer.java
+++ b/analytics-spring-boot-starter/src/main/java/com/segment/analytics/autoconfigure/SegmentAnalyticsCustomizer.java
@@ -1,0 +1,21 @@
+package com.segment.analytics.autoconfigure;
+
+import com.segment.analytics.Analytics;
+
+/**
+ * Callback interface that can be used to customize a {@link com.segment.analytics.Analytics.Builder
+ * Analytics.Builder}.
+ *
+ * @author Koen Punt
+ */
+@FunctionalInterface
+public interface SegmentAnalyticsCustomizer {
+
+  /**
+   * Callback to customize a {@link com.segment.analytics.Analytics.Builder Analytics.Builder}
+   * instance.
+   *
+   * @param analyticsBuilder the analytics builder to customize
+   */
+  void customize(Analytics.Builder analyticsBuilder);
+}

--- a/analytics-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/analytics-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.segment.analytics.autoconfigure.SegmentAnalyticsAutoConfiguration


### PR DESCRIPTION
This to allow customization of the client, without having to manually create the client.

This also includes the changes from #433.