### PR TITLE
Allow GsonBuilder to be passed in and used through Analytics and AnalyticsClient

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -149,6 +149,7 @@ public class Analytics {
     private List<Callback> callbacks;
     private int queueCapacity;
     private boolean forceTlsV1 = false;
+    private GsonBuilder gsonBuilder;
 
     Builder(String writeKey) {
       if (writeKey == null || writeKey.trim().length() == 0) {
@@ -248,6 +249,20 @@ public class Analytics {
       this.queueCapacity = capacity;
       return this;
     }
+
+    public Builder gsonBuilder(GsonBuilder gsonBuilder) {
+      if (gsonBuilder == null) {
+        throw new NullPointerException("Null gsonBuilder");
+      }
+
+      if (this.gsonBuilder != null) {
+        throw new IllegalStateException("gsonBuilder is already registered.");
+      }
+
+      this.gsonBuilder = gsonBuilder;
+      return this;
+    }
+
     /** Set the queueSize at which flushes should be triggered. */
     @Beta
     public Builder flushQueueSize(int flushQueueSize) {
@@ -341,11 +356,15 @@ public class Analytics {
 
     /** Create a {@link Analytics} client. */
     public Analytics build() {
-      Gson gson =
-          new GsonBuilder() //
-              .registerTypeAdapterFactory(new AutoValueAdapterFactory()) //
-              .registerTypeAdapter(Date.class, new ISO8601DateAdapter()) //
-              .create();
+      if (gsonBuilder == null) {
+        gsonBuilder = new GsonBuilder();
+      }
+
+      gsonBuilder
+          .registerTypeAdapterFactory(new AutoValueAdapterFactory())
+          .registerTypeAdapter(Date.class, new ISO8601DateAdapter());
+
+      Gson gson = gsonBuilder.create();
 
       if (endpoint == null) {
         if (uploadURL != null) {
@@ -450,7 +469,8 @@ public class Analytics {
               threadFactory,
               networkExecutor,
               callbacks,
-              writeKey);
+              writeKey,
+              gson);
 
       return new Analytics(analyticsClient, messageTransformers, messageInterceptors, log);
     }

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.google.gson.GsonBuilder;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -164,6 +165,34 @@ public class AnalyticsBuilderTest {
   @Test
   public void buildsWithValidInterceptor() {
     Analytics analytics = builder.messageInterceptor(mock(MessageInterceptor.class)).build();
+    assertThat(analytics).isNotNull();
+  }
+
+  @Test
+  public void nullGsonBuilder() {
+    try {
+      builder.gsonBuilder(null);
+      fail("Should fail for null gsonBuilder");
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("Null gsonBuilder");
+    }
+  }
+
+  @Test
+  public void duplicateGsonBuilder() {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    try {
+      builder.gsonBuilder(gsonBuilder).gsonBuilder(gsonBuilder);
+      fail("Should fail for duplicate gsonBuilder");
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage("gsonBuilder is already registered.");
+    }
+  }
+
+  @Test
+  public void buildsWithValidGsonBuilder() {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    Analytics analytics = builder.gsonBuilder(gsonBuilder).build();
     assertThat(analytics).isNotNull();
   }
 

--- a/analytics/src/test/java/com/segment/analytics/internal/AnalyticsClientTest.java
+++ b/analytics/src/test/java/com/segment/analytics/internal/AnalyticsClientTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import com.google.gson.Gson;
 import com.segment.analytics.Callback;
 import com.segment.analytics.Log;
 import com.segment.analytics.TestUtils.MessageBuilderTest;
@@ -105,7 +106,8 @@ public class AnalyticsClientTest {
         networkExecutor,
         Collections.singletonList(callback),
         isShutDown,
-        writeKey);
+        writeKey,
+        new Gson());
   }
 
   @Test
@@ -293,7 +295,8 @@ public class AnalyticsClientTest {
             networkExecutor,
             Collections.singletonList(callback),
             isShutDown,
-            writeKey);
+            writeKey,
+            new Gson());
 
     Map<String, String> properties = new HashMap<String, String>();
 
@@ -868,7 +871,8 @@ public class AnalyticsClientTest {
             networkExecutor,
             Collections.singletonList(callback),
             isShutDown,
-            writeKey);
+            writeKey,
+            new Gson());
 
     Map<String, String> properties = new HashMap<String, String>();
     properties.put("property3", generateDataOfSizeSpecialChars(MAX_MSG_SIZE, true));
@@ -909,7 +913,8 @@ public class AnalyticsClientTest {
             networkExecutor,
             Collections.singletonList(callback),
             isShutDown,
-            writeKey);
+            writeKey,
+            new Gson());
 
     Map<String, String> properties = new HashMap<String, String>();
     properties.put("property3", generateDataOfSizeSpecialChars(MAX_MSG_SIZE, true));
@@ -949,7 +954,8 @@ public class AnalyticsClientTest {
             networkExecutor,
             Collections.singletonList(callback),
             isShutDown,
-            writeKey);
+            writeKey,
+            new Gson());
 
     Map<String, String> properties = new HashMap<String, String>();
     properties.put("property3", generateDataOfSizeSpecialChars(1024 * 8, true));


### PR DESCRIPTION
Hi there,

I'm getting some issues when upgrading services to Java 17, where previously Gson was able to automatically deserialise things like java.util.Optional, and java.util.Duration, but now gets exceptions due to disallowed reflection.

Can we change Analytics / AnalyticsClient, to allow the GsonBuilder to be passed in, so that consumers can provide TypeAdapters and TypeAdapter factories as needed, for deserialisation of any classes that they'd like to send in analytics messages?
