### PR TITLE
Bump retrofit to fix CVEe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>8</java.version>
-    <kotlin.version>1.7.20</kotlin.version>
+    <kotlin.version>1.9.0</kotlin.version>
     <spotless.version>2.27.2</spotless.version>
-    <retrofit.version>2.9.0</retrofit.version>
+    <retrofit.version>2.11.0</retrofit.version>
     <auto.version>1.10.1</auto.version>
 
     <findbugs.version>3.0.1</findbugs.version>


### PR DESCRIPTION
`retrofit`, the compile-time dependency of `analytics-core`, has few vulnerabilities in the required version [`2.9.0`](https://mvnrepository.com/artifact/com.squareup.retrofit2/retrofit/2.9.0). They are resolved in version [`2.11.0`](https://mvnrepository.com/artifact/com.squareup.retrofit2/retrofit/2.11.0), but this version is compiled with Kotlin `1.9.x` (as opposed to `1.7.x` used in this project), so had to bump that as well.