### PR TITLE
This commit will update the okhttp version to 4.12.0 in pom.xml. This update is done to fix the Github issue #503.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <findbugs.version>3.0.1</findbugs.version>
     <gson.version>2.9.1</gson.version>
-    <okhttp.version>4.10.0</okhttp.version>
+    <okhttp.version>4.12.0</okhttp.version>
     <logging.version>4.10.0</logging.version>
     <guava.version>33.3.1-jre</guava.version>
     <backo.version>1.0.0</backo.version>


### PR DESCRIPTION
1. This commit will update the okhttp version to 4.12.0 in pom.xml. 
2. okhttp-4.12.0 uses okio-3.6.0. (Reference: https://central.sonatype.com/artifact/com.squareup.okhttp3/okhttp/4.12.0)
3. This update is done to fix the Github issue #503.