### PR TITLE
Align retrofit2 versions to ensure dependency convergence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
       <dependency>
         <groupId>com.squareup.retrofit2</groupId>
         <artifactId>converter-gson</artifactId>
-        <version>2.9.0</version>
+        <version>${retrofit.version}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.retrofit2</groupId>


### PR DESCRIPTION
When depending on com.segment.analytics.java:analytics and using Maven DependencyConvergence enforcer,
build will fail with:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (dependencies) on project commons-segment:
[ERROR] Rule 16: org.apache.maven.enforcer.rules.dependency.DependencyConvergence failed with message:
[ERROR] Failed while enforcing releasability.
[ERROR]
[ERROR] Dependency convergence error for com.squareup.retrofit2:retrofit:jar:2.11.0 paths to dependency are:
[ERROR]   +-com.segment.analytics.java:analytics:jar:3.5.2:compile
[ERROR]     +-com.segment.analytics.java:analytics-core:jar:3.5.2:compile
[ERROR]       +-com.squareup.retrofit2:retrofit:jar:2.11.0:compile
[ERROR] and
[ERROR]   +-com.segment.analytics.java:analytics:jar:3.5.2:compile
[ERROR]     +-com.squareup.retrofit2:converter-gson:jar:2.9.0:compile
[ERROR]       +-com.squareup.retrofit2:retrofit:jar:2.9.0:compile
[ERROR] and
[ERROR]   +-com.segment.analytics.java:analytics:jar:3.5.2:compile
[ERROR]     +-com.squareup.retrofit2:retrofit-mock:jar:2.11.0:compile
[ERROR]       +-com.squareup.retrofit2:retrofit:jar:2.11.0:compile
```