### PR TITLE
Harden CI: Artifactory OIDC, fork-aware workflows, tightened permissions

### DIFF
--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -57,7 +57,8 @@ runs:
 
         if [ -z "$ART_TOKEN" ]; then
           echo "::error::OIDC token exchange failed."
-          echo "$RESP" | jq 'if .access_token then .access_token="<redacted>" else . end' 2>/dev/null || echo "$RESP"
+          echo "$RESP" | jq 'walk(if type == "object" then with_entries(if (.key | test("token"; "i")) then .value = "<redacted>" else . end) else . end)' 2>/dev/null \
+            || echo "::error::(response withheld — not valid JSON)"
           exit 1
         fi
         echo "::add-mask::$ART_TOKEN"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -13,7 +13,7 @@ inputs:
   maven-repo:
     description: "Artifactory virtual Maven repository name"
     required: false
-    default: "virtual-maven-twilio"
+    default: "virtual-maven-thirdparty"
 
 runs:
   using: "composite"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -1,0 +1,71 @@
+name: 'Artifactory OIDC Authentication'
+description: 'Exchange GitHub OIDC token for Artifactory credentials and configure Maven settings.xml'
+
+inputs:
+  artifactory_url:
+    description: 'Artifactory base URL (e.g. https://segment.jfrog.io)'
+    required: true
+
+outputs:
+  token:
+    description: 'Artifactory access token'
+    value: ${{ steps.exchange.outputs.token }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get OIDC token
+      id: oidc
+      shell: bash
+      run: |
+        OIDC_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=jfrog-github" | jq -r '.value')
+        echo "::add-mask::$OIDC_TOKEN"
+        echo "oidc_token=$OIDC_TOKEN" >> "$GITHUB_OUTPUT"
+
+    - name: Exchange OIDC token for Artifactory token
+      id: exchange
+      shell: bash
+      env:
+        ARTIFACTORY_URL: ${{ inputs.artifactory_url }}
+      run: |
+        HOST=$(echo "$ARTIFACTORY_URL" | sed 's|https://||')
+        ART_TOKEN=$(curl -s -X POST \
+          "$ARTIFACTORY_URL/access/api/v1/oidc/token" \
+          -H "Content-Type: application/json" \
+          -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token\": \"${{ steps.oidc.outputs.oidc_token }}\", \"subject_token_type\": \"urn:ietf:params:oauth:token-type:id_token\", \"provider_name\": \"github\"}" \
+          | jq -r '.access_token')
+        echo "::add-mask::$ART_TOKEN"
+        echo "token=$ART_TOKEN" >> "$GITHUB_OUTPUT"
+        echo "host=$HOST" >> "$GITHUB_OUTPUT"
+
+    - name: Write Maven settings.xml
+      shell: bash
+      env:
+        ART_TOKEN: ${{ steps.exchange.outputs.token }}
+        ART_HOST: ${{ steps.exchange.outputs.host }}
+        ARTIFACTORY_URL: ${{ inputs.artifactory_url }}
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml << 'EOF'
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+          <mirrors>
+            <mirror>
+              <id>artifactory</id>
+              <mirrorOf>central</mirrorOf>
+              <url>__ARTIFACTORY_URL__/artifactory/virtual-maven-thirdparty</url>
+            </mirror>
+          </mirrors>
+          <servers>
+            <server>
+              <id>artifactory</id>
+              <username>_</username>
+              <password>__ART_TOKEN__</password>
+            </server>
+          </servers>
+        </settings>
+        EOF
+        sed -i "s|__ARTIFACTORY_URL__|${ARTIFACTORY_URL}|g" ~/.m2/settings.xml
+        sed -i "s|__ART_TOKEN__|${ART_TOKEN}|g" ~/.m2/settings.xml

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -1,53 +1,71 @@
-name: 'Artifactory OIDC Authentication'
-description: 'Exchange GitHub OIDC token for Artifactory credentials and configure Maven settings.xml'
+name: "Artifactory OIDC Auth"
+description: "Exchange GitHub OIDC token for Artifactory access token and configure Maven"
 
 inputs:
-  artifactory_url:
-    description: 'Artifactory base URL (e.g. https://segment.jfrog.io)'
-    required: true
-
-outputs:
-  token:
-    description: 'Artifactory access token'
-    value: ${{ steps.exchange.outputs.token }}
+  artifactory-url:
+    description: "JFrog platform base URL. Falls back to ARTIFACTORY_URL env var."
+    required: false
+    default: ""
+  oidc-provider-name:
+    description: "OIDC provider name configured in Artifactory"
+    required: false
+    default: "github-actions-segmentio"
+  maven-repo:
+    description: "Artifactory virtual Maven repository name"
+    required: false
+    default: "virtual-maven-thirdparty"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: Get OIDC token
-      id: oidc
-      shell: bash
-      run: |
-        OIDC_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=jfrog-github" | jq -r '.value')
-        echo "::add-mask::$OIDC_TOKEN"
-        echo "oidc_token=$OIDC_TOKEN" >> "$GITHUB_OUTPUT"
-
-    - name: Exchange OIDC token for Artifactory token
-      id: exchange
+    - name: Exchange GitHub OIDC token for Artifactory token
       shell: bash
       env:
-        ARTIFACTORY_URL: ${{ inputs.artifactory_url }}
+        INPUT_ARTIFACTORY_URL: ${{ inputs.artifactory-url }}
+        OIDC_PROVIDER_NAME: ${{ inputs.oidc-provider-name }}
+        MAVEN_REPO: ${{ inputs.maven-repo }}
       run: |
-        HOST=$(echo "$ARTIFACTORY_URL" | sed 's|https://||')
-        ART_TOKEN=$(curl -s -X POST \
-          "$ARTIFACTORY_URL/access/api/v1/oidc/token" \
-          -H "Content-Type: application/json" \
-          -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token\": \"${{ steps.oidc.outputs.oidc_token }}\", \"subject_token_type\": \"urn:ietf:params:oauth:token-type:id_token\", \"provider_name\": \"github\"}" \
-          | jq -r '.access_token')
+        set -euo pipefail
+        ARTIFACTORY_URL="${INPUT_ARTIFACTORY_URL:-${ARTIFACTORY_URL:-}}"
+        if [ -z "${ARTIFACTORY_URL}" ]; then
+          echo "::error::ARTIFACTORY_URL is not set (pass as input or set as env var)"; exit 1
+        fi
+
+        OIDC_JWT=$(curl -sS \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${ARTIFACTORY_URL}" \
+          -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" | jq -r '.value')
+
+        if [ -z "$OIDC_JWT" ] || [ "$OIDC_JWT" = "null" ]; then
+          echo "::error::Failed to obtain GitHub OIDC token"; exit 1
+        fi
+
+        decode_seg() { local s="${1}"; local m=$(( ${#s} % 4 )); [ $m -ne 0 ] && s="${s}$(printf '=%.0s' $(seq 1 $((4-m))))"; echo "$s" | tr '_-' '/+' | base64 -d 2>/dev/null; }
+        PAYLOAD=$(decode_seg "$(echo "$OIDC_JWT" | cut -d. -f2)")
+        echo "OIDC token claims:"
+        echo "  sub = $(echo "$PAYLOAD" | jq -r '.sub')"
+        echo "  aud = $(echo "$PAYLOAD" | jq -r '.aud')"
+        echo "  iss = $(echo "$PAYLOAD" | jq -r '.iss')"
+
+        RESP=$(curl -sS "${ARTIFACTORY_URL}/access/api/v1/oidc/token" \
+          -H 'Content-Type: application/json' \
+          -d "{\"grant_type\":\"urn:ietf:params:oauth:grant-type:token-exchange\",
+               \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\",
+               \"subject_token\":\"${OIDC_JWT}\",
+               \"provider_name\":\"${OIDC_PROVIDER_NAME}\"}")
+
+        ART_TOKEN=$(echo "$RESP" | jq -r '.access_token // empty')
+
+        if [ -z "$ART_TOKEN" ]; then
+          echo "::error::OIDC token exchange failed."
+          echo "$RESP" | jq 'if .access_token then .access_token="<redacted>" else . end' 2>/dev/null || echo "$RESP"
+          exit 1
+        fi
         echo "::add-mask::$ART_TOKEN"
-        echo "token=$ART_TOKEN" >> "$GITHUB_OUTPUT"
-        echo "host=$HOST" >> "$GITHUB_OUTPUT"
 
-    - name: Write Maven settings.xml
-      shell: bash
-      env:
-        ART_TOKEN: ${{ steps.exchange.outputs.token }}
-        ART_HOST: ${{ steps.exchange.outputs.host }}
-        ARTIFACTORY_URL: ${{ inputs.artifactory_url }}
-      run: |
+        HOST=$(echo "${ARTIFACTORY_URL}" | sed -E 's#^https?://##')
+
         mkdir -p ~/.m2
-        cat > ~/.m2/settings.xml << 'EOF'
+        cat > ~/.m2/settings.xml << EOF
         <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
@@ -55,17 +73,16 @@ runs:
             <mirror>
               <id>artifactory</id>
               <mirrorOf>central</mirrorOf>
-              <url>__ARTIFACTORY_URL__/artifactory/virtual-maven-thirdparty</url>
+              <url>https://${HOST}/artifactory/${MAVEN_REPO}</url>
             </mirror>
           </mirrors>
           <servers>
             <server>
               <id>artifactory</id>
               <username>_</username>
-              <password>__ART_TOKEN__</password>
+              <password>${ART_TOKEN}</password>
             </server>
           </servers>
         </settings>
         EOF
-        sed -i "s|__ARTIFACTORY_URL__|${ARTIFACTORY_URL}|g" ~/.m2/settings.xml
-        sed -i "s|__ART_TOKEN__|${ART_TOKEN}|g" ~/.m2/settings.xml
+        echo "Configured Maven to resolve through Artifactory (${MAVEN_REPO})"

--- a/.github/actions/artifactory-oidc/action.yml
+++ b/.github/actions/artifactory-oidc/action.yml
@@ -13,7 +13,7 @@ inputs:
   maven-repo:
     description: "Artifactory virtual Maven repository name"
     required: false
-    default: "virtual-maven-thirdparty"
+    default: "virtual-maven-twilio"
 
 runs:
   using: "composite"
@@ -72,7 +72,7 @@ runs:
           <mirrors>
             <mirror>
               <id>artifactory</id>
-              <mirrorOf>central</mirrorOf>
+              <mirrorOf>*</mirrorOf>
               <url>https://${HOST}/artifactory/${MAVEN_REPO}</url>
             </mirror>
           </mirrors>
@@ -83,6 +83,22 @@ runs:
               <password>${ART_TOKEN}</password>
             </server>
           </servers>
+          <profiles>
+            <profile>
+              <id>artifactory</id>
+              <pluginRepositories>
+                <pluginRepository>
+                  <id>artifactory</id>
+                  <url>https://${HOST}/artifactory/${MAVEN_REPO}</url>
+                  <releases><enabled>true</enabled></releases>
+                  <snapshots><enabled>false</enabled></snapshots>
+                </pluginRepository>
+              </pluginRepositories>
+            </profile>
+          </profiles>
+          <activeProfiles>
+            <activeProfile>artifactory</activeProfile>
+          </activeProfiles>
         </settings>
         EOF
         echo "Configured Maven to resolve through Artifactory (${MAVEN_REPO})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
+jobs:
+  lint:
+    name: Lint (spotless + animal-sniffer)
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+
+      - name: Artifactory OIDC
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
+        with:
+          artifactory_url: ${{ vars.ARTIFACTORY_URL }}
+
+      - name: Spotless check
+        run: mvn -B spotless:check
+
+      - name: Animal Sniffer check
+        run: mvn -B animal-sniffer:check
+
+  test:
+    name: Test (Java ${{ matrix.java-version }})
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: ['11', '17', '21']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+          cache: maven
+
+      - name: Artifactory OIDC
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
+        with:
+          artifactory_url: ${{ vars.ARTIFACTORY_URL }}
+
+      - name: Run tests
+        run: mvn -B test
+
+  build:
+    name: Build verification
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'ubuntu-x64' }}
+    needs: [lint, test]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+
+      - name: Artifactory OIDC
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: ./.github/actions/artifactory-oidc
+        with:
+          artifactory_url: ${{ vars.ARTIFACTORY_URL }}
+
+      - name: Build
+        run: mvn -B package -DskipTests
+
+      - name: Verify
+        run: mvn -B verify -DskipTests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,74 @@
+name: Deploy to Maven Central
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
+jobs:
+  test:
+    name: Pre-deploy tests
+    runs-on: ubuntu-x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+
+      - name: Artifactory OIDC
+        uses: ./.github/actions/artifactory-oidc
+        with:
+          artifactory_url: ${{ vars.ARTIFACTORY_URL }}
+
+      - name: Run tests
+        run: mvn -B test
+
+  deploy:
+    name: Deploy to Maven Central
+    runs-on: ubuntu-x64
+    needs: [test]
+    environment: maven-central
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+          server-id: central
+          server-username: CI_DEPLOY_USERNAME
+          server-password: CI_DEPLOY_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Artifactory OIDC
+        uses: ./.github/actions/artifactory-oidc
+        with:
+          artifactory_url: ${{ vars.ARTIFACTORY_URL }}
+
+      - name: Deploy to Maven Central
+        env:
+          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+          CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          mvn -B deploy \
+            -DskipTests \
+            -Dgpg.passphrase="$GPG_PASSPHRASE" \
+            -P release

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,18 +1,12 @@
-# E2E Tests for analytics-java
-# Copy this file to: analytics-java/.github/workflows/e2e-tests.yml
-#
-# This workflow:
-# 1. Checks out the SDK and sdk-e2e-tests repos
-# 2. Builds the SDK and e2e-cli
-# 3. Runs the e2e test suite
-
 name: E2E Tests
 
 on:
   push:
-    branches: [main, master]
+    branches: [master]
   pull_request:
-    branches: [main, master]
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1-5'
   workflow_dispatch:
     inputs:
       e2e_tests_ref:
@@ -20,47 +14,59 @@ on:
         required: false
         default: 'main'
 
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ARTIFACTORY_URL: ${{ vars.ARTIFACTORY_URL }}
+
 jobs:
   e2e-tests:
-    # Skip on fork PRs where repo secrets aren't available
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-latest
+    name: E2E Test Suite
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-x64
 
     steps:
       - name: Checkout SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: sdk
 
       - name: Checkout sdk-e2e-tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: segmentio/sdk-e2e-tests
           ref: ${{ inputs.e2e_tests_ref || 'main' }}
-          token: ${{ secrets.E2E_TESTS_TOKEN }}
           path: sdk-e2e-tests
 
-      - name: Setup Java
-        uses: actions/setup-java@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
         with:
           distribution: 'temurin'
           java-version: '11'
+          cache: maven
+
+      - name: Artifactory OIDC
+        uses: ./sdk/.github/actions/artifactory-oidc
+        with:
+          artifactory_url: ${{ vars.ARTIFACTORY_URL }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
           node-version: '20'
 
       - name: Build Java SDK and e2e-cli
         working-directory: sdk
-        run: mvn package -pl e2e-cli -am -DskipTests
+        run: mvn -B package -pl e2e-cli -am -DskipTests
 
       - name: Find e2e-cli jar
         id: find-jar
         working-directory: sdk
         run: |
           JAR_PATH=$(find e2e-cli/target -name "e2e-cli-*-jar-with-dependencies.jar" | head -1)
-          echo "jar_path=$JAR_PATH" >> $GITHUB_OUTPUT
+          echo "jar_path=$JAR_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Run E2E tests
         working-directory: sdk-e2e-tests
@@ -71,7 +77,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-test-results
           path: sdk-e2e-tests/test-results/

--- a/pom.xml
+++ b/pom.xml
@@ -248,15 +248,6 @@
 
     <plugins>
       <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.9.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <publishingServerId>central</publishingServerId>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.0.0</version>
@@ -341,4 +332,24 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <!-- Activated explicitly during deploy: mvn -P release deploy -->
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.9.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>8</java.version>
     <kotlin.version>1.9.0</kotlin.version>
-    <spotless.version>2.27.2</spotless.version>
+    <spotless.version>2.44.0</spotless.version>
     <retrofit.version>2.11.0</retrofit.version>
     <auto.version>1.10.1</auto.version>
 


### PR DESCRIPTION
## Summary

- Add Artifactory OIDC composite action — exchanges GitHub OIDC token for short-lived Artifactory access token, writes \`~/.m2/settings.xml\` mirroring \`virtual-maven-thirdparty\`
- Add \`ci.yml\` — replaces \`publish.yaml\`, fork-aware runner selection, Java 11/17/21 matrix, spotless + animal-sniffer checks, SHA-pinned actions
- Add \`deploy.yml\` — tag-triggered, \`environment: maven-central\` gate, GPG signing, tightened permissions
- Update \`e2e-tests.yml\` — remove \`E2E_TESTS_TOKEN\` (sdk-e2e-tests going public), fork-aware

## Notes

- Maven Central has no OIDC trusted publishing — GPG signing + Sonatype credentials remain required
- Old \`publish.yaml\`, \`java8.yml\`, \`java11.yml\`, \`java17.yml\`, \`e2e.yaml\` can be deleted once new workflows are validated

## Test plan

- [ ] CI runs on this PR
- [ ] Artifactory OIDC exchange succeeds on same-repo CI
- [ ] Before merging: set \`ARTIFACTORY_URL\` repository variable
- [ ] Before merging: create \`maven-central\` GitHub environment with protection rules
- [ ] Before merging: migrate GPG + Sonatype credentials to environment-scoped secrets